### PR TITLE
Fix/seedfarmer yaml required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 - update DeploymentManifest to support targetAccountMappings and regionMappings
 - move deployment level Parameters (dockerCredentialsSecret, permissionBoundaryArn) to mappings
 ### Fixes
+- fix import failure of seedfarmer top-level module if seedfarmer.yaml doesn't exist
 
 ## v0.1.4 (2022-08-16)
 ### New

--- a/seedfarmer/__init__.py
+++ b/seedfarmer/__init__.py
@@ -51,37 +51,3 @@ def enable_info(format: str) -> None:
 
 
 enable_info(INFO_LOGGING_FORMAT)
-
-# Locate the config for seedfarmer
-CONFIG_FILE = "seedfarmer.yaml"
-OPS_ROOT = os.getcwd()
-count = 0
-while not os.path.exists(os.path.join(OPS_ROOT, CONFIG_FILE)):
-    if count >= 4:
-        _logger.error("The seedfarmer.yaml was not found at the root of your project.  Please set it and rerun.")
-        exit(0)
-    else:
-        OPS_ROOT = pathlib.Path(OPS_ROOT).parent  # type: ignore
-        count += 1
-
-with open(os.path.join(OPS_ROOT, CONFIG_FILE), "r") as file:
-    config_data = yaml.safe_load(file)
-
-PROJECT = config_data["project"]
-DESCRIPTION = config_data["description"] if "description" in config_data else "NEW PROJECT"
-
-
-@codeseeder.configure(PROJECT.lower(), deploy_if_not_exists=True)
-def configure(configuration: CodeSeederConfig) -> None:
-    LOGGER.debug(f"OPS ROOT (OPS_ROOT) is {OPS_ROOT}")
-    configuration.timeout = 120
-    configuration.codebuild_image = "public.ecr.aws/v3o4w1g6/aws-codeseeder/code-build-base:2.2.0"
-    configuration.pre_build_commands = [
-        (
-            "nohup /usr/local/bin/dockerd --host=unix:///var/run/docker.sock"
-            " --host=tcp://127.0.0.1:2375 --storage-driver=overlay2 &"
-        ),
-        'timeout 15 sh -c "until docker info; do echo .; sleep 1; done"',
-    ]
-    configuration.python_modules = [f"seed-farmer=={__version__}"]
-    configuration.runtime_versions = {"nodejs": "14", "python": "3.9"}

--- a/seedfarmer/__init__.py
+++ b/seedfarmer/__init__.py
@@ -14,13 +14,8 @@
 
 
 import logging
-import os
-import pathlib
 
 import pkg_resources
-import yaml
-from aws_codeseeder import LOGGER, codeseeder
-from aws_codeseeder.codeseeder import CodeSeederConfig
 
 from seedfarmer.__metadata__ import __description__, __license__, __title__
 

--- a/seedfarmer/__main__.py
+++ b/seedfarmer/__main__.py
@@ -25,7 +25,7 @@ import seedfarmer.mgmt.deploy_utils as du
 import seedfarmer.mgmt.module_info as mi
 import seedfarmer.mgmt.module_init as minit
 from seedfarmer import DEBUG_LOGGING_FORMAT, commands, enable_debug, utils
-from seedfarmer.config import PROJECT, DESCRIPTION
+from seedfarmer.config import DESCRIPTION, PROJECT
 from seedfarmer.output_utils import print_bolded, print_deployment_inventory, print_json, print_manifest_inventory
 
 _logger: logging.Logger = logging.getLogger(__name__)

--- a/seedfarmer/__main__.py
+++ b/seedfarmer/__main__.py
@@ -24,7 +24,8 @@ import seedfarmer
 import seedfarmer.mgmt.deploy_utils as du
 import seedfarmer.mgmt.module_info as mi
 import seedfarmer.mgmt.module_init as minit
-from seedfarmer import DEBUG_LOGGING_FORMAT, DESCRIPTION, PROJECT, commands, enable_debug, utils
+from seedfarmer import DEBUG_LOGGING_FORMAT, commands, enable_debug, utils
+from seedfarmer.config import PROJECT, DESCRIPTION
 from seedfarmer.output_utils import print_bolded, print_deployment_inventory, print_json, print_manifest_inventory
 
 _logger: logging.Logger = logging.getLogger(__name__)

--- a/seedfarmer/commands/_deployment_commands.py
+++ b/seedfarmer/commands/_deployment_commands.py
@@ -23,8 +23,9 @@ import checksumdir
 import yaml
 
 import seedfarmer.mgmt.deploy_utils as du
-from seedfarmer import OPS_ROOT, commands
+from seedfarmer import commands
 from seedfarmer.commands._parameter_commands import load_parameter_values
+from seedfarmer.config import OPS_ROOT
 from seedfarmer.mgmt.module_info import (
     _get_deployspec_path,
     _get_modulestack_path,

--- a/seedfarmer/commands/_module_commands.py
+++ b/seedfarmer/commands/_module_commands.py
@@ -23,7 +23,7 @@ import botocore.exceptions
 from aws_codeseeder import codeseeder
 from aws_codeseeder.errors import CodeSeederRuntimeError
 
-from seedfarmer import CONFIG_FILE, OPS_ROOT, PROJECT
+from seedfarmer.config import CONFIG_FILE, OPS_ROOT, PROJECT
 from seedfarmer.models.deploy_responses import CodeSeederMetadata, ModuleDeploymentResponse, StatusType
 from seedfarmer.models.manifests import DeploySpec, ModuleParameter
 from seedfarmer.utils import generate_hash

--- a/seedfarmer/commands/_parameter_commands.py
+++ b/seedfarmer/commands/_parameter_commands.py
@@ -16,7 +16,7 @@
 import logging
 from typing import Any, Dict, List, Optional, Tuple, cast
 
-from seedfarmer import PROJECT
+from seedfarmer.config import PROJECT
 from seedfarmer.mgmt.module_info import get_module_metadata
 from seedfarmer.models.manifests import ModuleParameter
 from seedfarmer.utils import upper_snake_case

--- a/seedfarmer/commands/_stack_commands.py
+++ b/seedfarmer/commands/_stack_commands.py
@@ -22,7 +22,7 @@ from aws_codeseeder import codeseeder, commands, services
 from cfn_tools import load_yaml
 
 import seedfarmer.services._iam as iam
-from seedfarmer import OPS_ROOT, PROJECT
+from seedfarmer.config import OPS_ROOT, PROJECT
 from seedfarmer.mgmt.module_info import _get_module_stack_names
 from seedfarmer.models.manifests import DeploymentManifest, ModuleParameter
 from seedfarmer.services._service_utils import get_account_id, get_region

--- a/seedfarmer/config/__init__.py
+++ b/seedfarmer/config/__init__.py
@@ -16,11 +16,9 @@
 import logging
 import os
 import pathlib
-
 from typing import Any, Dict
 
 import yaml
-
 from aws_codeseeder import LOGGER, codeseeder
 from aws_codeseeder.codeseeder import CodeSeederConfig
 
@@ -33,6 +31,7 @@ OPS_ROOT = os.getcwd()
 PROJECT = ""
 DESCRIPTION = ""
 
+
 def _load_config_data() -> None:
     count = 0
     global CONFIG_FILE
@@ -43,7 +42,9 @@ def _load_config_data() -> None:
     while not os.path.exists(os.path.join(OPS_ROOT, CONFIG_FILE)):
         if count >= 4:
             _logger.error("The seedfarmer.yaml was not found at the root of your project.  Please set it and rerun.")
-            raise FileNotFoundError("The seedfarmer.yaml was not found at the root of your project.  Please set it and rerun.")
+            raise FileNotFoundError(
+                "The seedfarmer.yaml was not found at the root of your project.  Please set it and rerun."
+            )
         else:
             OPS_ROOT = pathlib.Path(OPS_ROOT).parent  # type: ignore
             count += 1
@@ -53,7 +54,9 @@ def _load_config_data() -> None:
         PROJECT = config_data["project"]
         DESCRIPTION = config_data["description"] if "description" in config_data else "NEW PROJECT"
 
+
 _load_config_data()
+
 
 @codeseeder.configure(PROJECT.lower(), deploy_if_not_exists=True)
 def configure(configuration: CodeSeederConfig) -> None:

--- a/seedfarmer/config/__init__.py
+++ b/seedfarmer/config/__init__.py
@@ -1,0 +1,71 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License").
+#    You may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+
+import logging
+import os
+import pathlib
+
+from typing import Any, Dict
+
+import yaml
+
+from aws_codeseeder import LOGGER, codeseeder
+from aws_codeseeder.codeseeder import CodeSeederConfig
+
+from seedfarmer import __version__
+
+_logger: logging.Logger = logging.getLogger(__name__)
+
+CONFIG_FILE = "seedfarmer.yaml"
+OPS_ROOT = os.getcwd()
+PROJECT = ""
+DESCRIPTION = ""
+
+def _load_config_data() -> None:
+    count = 0
+    global CONFIG_FILE
+    global OPS_ROOT
+    global PROJECT
+    global DESCRIPTION
+
+    while not os.path.exists(os.path.join(OPS_ROOT, CONFIG_FILE)):
+        if count >= 4:
+            _logger.error("The seedfarmer.yaml was not found at the root of your project.  Please set it and rerun.")
+            raise FileNotFoundError("The seedfarmer.yaml was not found at the root of your project.  Please set it and rerun.")
+        else:
+            OPS_ROOT = pathlib.Path(OPS_ROOT).parent  # type: ignore
+            count += 1
+
+    with open(os.path.join(OPS_ROOT, CONFIG_FILE), "r") as file:
+        config_data: Dict[str, Any] = yaml.safe_load(file)
+        PROJECT = config_data["project"]
+        DESCRIPTION = config_data["description"] if "description" in config_data else "NEW PROJECT"
+
+_load_config_data()
+
+@codeseeder.configure(PROJECT.lower(), deploy_if_not_exists=True)
+def configure(configuration: CodeSeederConfig) -> None:
+    LOGGER.debug(f"OPS ROOT (OPS_ROOT) is {OPS_ROOT}")
+    configuration.timeout = 120
+    configuration.codebuild_image = "public.ecr.aws/v3o4w1g6/aws-codeseeder/code-build-base:2.2.0"
+    configuration.pre_build_commands = [
+        (
+            "nohup /usr/local/bin/dockerd --host=unix:///var/run/docker.sock"
+            " --host=tcp://127.0.0.1:2375 --storage-driver=overlay2 &"
+        ),
+        'timeout 15 sh -c "until docker info; do echo .; sleep 1; done"',
+    ]
+    configuration.python_modules = [f"seed-farmer=={__version__}"]
+    configuration.runtime_versions = {"nodejs": "14", "python": "3.9"}

--- a/seedfarmer/mgmt/module_info.py
+++ b/seedfarmer/mgmt/module_info.py
@@ -17,7 +17,7 @@ import os
 from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple
 
-from seedfarmer import OPS_ROOT, PROJECT
+from seedfarmer.config import OPS_ROOT, PROJECT
 from seedfarmer.services import _secrets_manager as secrets
 from seedfarmer.services import _ssm as store
 from seedfarmer.utils import generate_hash

--- a/seedfarmer/mgmt/module_init.py
+++ b/seedfarmer/mgmt/module_init.py
@@ -18,7 +18,7 @@ from typing import Optional
 
 from cookiecutter.main import cookiecutter
 
-from seedfarmer import CONFIG_FILE, OPS_ROOT, PROJECT
+from seedfarmer.config import CONFIG_FILE, OPS_ROOT, PROJECT
 
 _logger: logging.Logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
*Issue #, if available:* fixes #79

*Description of changes:*
moved loading of seedfarmer.yaml into seedfarmer.config module to enable importing of top-level seedfarmer module even if the seedfarmer.yaml doesn't exist. importing of seedfarmer.config _will_ fail if seedfarmer.yaml doesn't exist.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
