### PR TITLE
new CLI command stubs to bootstrap Toolchain and Target accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ## Unreleased
 
 ### New
+- new CLI bootstrap commands for Toolchain and Target accounts
 
 ### Changes
 - update DeploymentManifest to support targetAccountMappings and regionMappings

--- a/seedfarmer/__main__.py
+++ b/seedfarmer/__main__.py
@@ -19,7 +19,7 @@ import click
 
 import seedfarmer
 from seedfarmer import DEBUG_LOGGING_FORMAT, commands, enable_debug
-from seedfarmer.cli_groups import init, list, remove, store
+from seedfarmer.cli_groups import bootstrap, init, list, remove, store
 from seedfarmer.config import DESCRIPTION, PROJECT
 from seedfarmer.output_utils import print_bolded
 
@@ -119,5 +119,6 @@ def main() -> int:
     cli.add_command(list)
     cli.add_command(init)
     cli.add_command(version)
+    cli.add_command(bootstrap)
     cli()
     return 0

--- a/seedfarmer/cli_groups/__init__.py
+++ b/seedfarmer/cli_groups/__init__.py
@@ -12,9 +12,10 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+from seedfarmer.cli_groups._bootstrap_group import bootstrap
 from seedfarmer.cli_groups._init_group import init
 from seedfarmer.cli_groups._list_group import list
 from seedfarmer.cli_groups._remove_group import remove
 from seedfarmer.cli_groups._store_group import store
 
-__all__ = ["init", "list", "remove", "store"]
+__all__ = ["bootstrap", "init", "list", "remove", "store"]

--- a/seedfarmer/cli_groups/_bootstrap_group.py
+++ b/seedfarmer/cli_groups/_bootstrap_group.py
@@ -1,0 +1,93 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License").
+#    You may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+
+import logging
+from typing import List, Optional
+
+import click
+
+from seedfarmer import DEBUG_LOGGING_FORMAT, enable_debug
+from seedfarmer.config import PROJECT
+
+_logger: logging.Logger = logging.getLogger(__name__)
+
+
+@click.group(name="bootstrap", help="Bootstrap (initialize) a Toolchain or Target account")
+def bootstrap() -> None:
+    f"""Bootstrap a Toolchain or Target account for project {PROJECT.upper()}"""
+    pass
+
+
+@bootstrap.command(
+    name="toolchain",
+    help="Bootstrap a Toolchain account.",
+)
+@click.argument("project", type=str, required=True)
+@click.option(
+    "--trusted-principal",
+    "-t",
+    help="ARN of Principals trusted to assume the Toolchain Role",
+    multiple=True,
+    required=False,
+    default=[],
+)
+@click.option(
+    "--permission-boundary",
+    "-p",
+    help="ARN of a Managed Policy to set as the Permission Boundary on the Toolchain Role",
+    required=False,
+    default=None,
+)
+@click.option(
+    "--as-target/--not-as-target",
+    type=bool,
+    default=False,
+    help="Optionally also bootstrap the account as a Target account",
+    required=False,
+)
+@click.option("--debug/--no-debug", default=False, help="Enable detail logging", show_default=True)
+def bootstrap_toolchain(
+    project: str, trusted_principal: List[str], permission_boundary: Optional[str], as_target: bool, debug: bool
+) -> None:
+    if debug:
+        enable_debug(format=DEBUG_LOGGING_FORMAT)
+    _logger.debug("Bootstrapping a Toolchain account for Project %s", project)
+    pass
+
+
+@bootstrap.command(
+    name="target",
+    help="Bootstrap a Target account.",
+)
+@click.argument("project", type=str, required=True)
+@click.option(
+    "--toolchain-account",
+    "-t",
+    required=True,
+    help="Account Id of the Toolchain account trusted to assume the Target account's Deployment Role",
+)
+@click.option(
+    "--permission-boundary",
+    "-p",
+    help="ARN of a Managed Policy to set as the Permission Boundary on the Toolchain Role",
+    required=False,
+    default=None,
+)
+@click.option("--debug/--no-debug", default=False, help="Enable detail logging", show_default=True)
+def bootstrap_target(project: str, toolchain_account: str, permission_boundary: Optional[str], debug: bool) -> None:
+    if debug:
+        enable_debug(format=DEBUG_LOGGING_FORMAT)
+    _logger.debug("Bootstrapping a Target account for Project %s", project)
+    pass

--- a/seedfarmer/cli_groups/_init_group.py
+++ b/seedfarmer/cli_groups/_init_group.py
@@ -31,17 +31,13 @@ def init() -> None:
 
 @init.command(
     name="project",
-    help=(
-        "Initialize a project. " "Make sure seedfarmer.yaml is present in the same location you execute this command!!"
-    ),
+    help="Initialize a project. Make sure seedfarmer.yaml is present in the same location you execute this command!!",
 )
 @click.option(
     "--template-url",
     "-t",
     default="https://github.com/awslabs/seed-farmer.git",
-    help=(
-        "The template URL. If not specified, the default template repo is " "`https://github.com/awslabs/seed-farmer`"
-    ),
+    help="The template URL. If not specified, the default template repo is `https://github.com/awslabs/seed-farmer`",
     required=False,
 )
 def init_project(template_url: str) -> None:


### PR DESCRIPTION
*Issue #, if available:*  Closes #63 and Closes #64

*Description of changes:*
- new CLI command stubs to bootstrap Toolchain and Target accounts

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
