### PR TITLE
added CFN synth support for toolchain and target accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,15 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 
 ### New
 - new CLI bootstrap commands for Toolchain and Target accounts
+- create SessionManager class for supporting multi-account, multi-region
+- bootstrap command support to generate CFN templates for Toolchain and Target accounts
+
 
 ### Changes
 - update DeploymentManifest to support targetAccountMappings and regionMappings
 - move deployment level Parameters (dockerCredentialsSecret, permissionBoundaryArn) to mappings
 - refactor cli commands/groups to reduce line count in `__main__.py`
+- poved projectpolicy.yaml into resources/.
 
 ### Fixes
 - fix import failure of seedfarmer top-level module if seedfarmer.yaml doesn't exist

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+
+recursive-include seedfarmer/resources

--- a/seedfarmer/__init__.py
+++ b/seedfarmer/__init__.py
@@ -14,6 +14,7 @@
 
 
 import logging
+import os
 
 import pkg_resources
 
@@ -25,6 +26,8 @@ __version__: str = pkg_resources.get_distribution(__title__).version
 
 DEBUG_LOGGING_FORMAT = "[%(asctime)s][%(filename)-13s:%(lineno)3d] %(message)s"
 INFO_LOGGING_FORMAT = "[%(filename)-13s:%(lineno)3d] %(message)s"
+
+CLI_ROOT = os.path.dirname(os.path.abspath(__file__))
 
 
 def enable_debug(format: str) -> None:

--- a/seedfarmer/cli_groups/_bootstrap_group.py
+++ b/seedfarmer/cli_groups/_bootstrap_group.py
@@ -78,7 +78,7 @@ def bootstrap_toolchain(
     _logger.debug("Bootstrapping a Toolchain account for Project %s", project)
     bootstrap_toolchain_account(
         project_name="exampleproj",
-        principalARN=trusted_principal,
+        principalARNs=trusted_principal,
         permissionsBoundaryARN=permission_boundary,
         synthesize=synth,
     )

--- a/seedfarmer/cli_groups/_bootstrap_group.py
+++ b/seedfarmer/cli_groups/_bootstrap_group.py
@@ -19,14 +19,14 @@ from typing import List, Optional
 import click
 
 from seedfarmer import DEBUG_LOGGING_FORMAT, enable_debug
-from seedfarmer.config import PROJECT
+from seedfarmer.commands import bootstrap_target_account, bootstrap_toolchain_account
 
 _logger: logging.Logger = logging.getLogger(__name__)
 
 
 @click.group(name="bootstrap", help="Bootstrap (initialize) a Toolchain or Target account")
 def bootstrap() -> None:
-    f"""Bootstrap a Toolchain or Target account for project {PROJECT.upper()}"""
+    """Bootstrap a Toolchain or Target account for project"""
     pass
 
 
@@ -57,14 +57,40 @@ def bootstrap() -> None:
     help="Optionally also bootstrap the account as a Target account",
     required=False,
 )
+@click.option(
+    "--synth/--no-synth",
+    type=bool,
+    default=False,
+    help="Synthesize a CFN template only...do not deploy",
+    required=False,
+)
 @click.option("--debug/--no-debug", default=False, help="Enable detail logging", show_default=True)
 def bootstrap_toolchain(
-    project: str, trusted_principal: List[str], permission_boundary: Optional[str], as_target: bool, debug: bool
+    project: str,
+    trusted_principal: List[str],
+    permission_boundary: Optional[str],
+    as_target: bool,
+    synth: bool,
+    debug: bool,
 ) -> None:
     if debug:
         enable_debug(format=DEBUG_LOGGING_FORMAT)
     _logger.debug("Bootstrapping a Toolchain account for Project %s", project)
-    pass
+    bootstrap_toolchain_account(
+        project_name="exampleproj",
+        principalARN=trusted_principal,
+        permissionsBoundaryARN=permission_boundary,
+        synthesize=synth,
+    )
+    # if as_target:
+    #     #  Go get the account id and call the target command
+    #     toolchain_account = None
+    #     bootstrap_target_account(
+    #         toolchain_account_id=toolchain_account,
+    #         project_name="exampleproj",
+    #         permissionsBoundaryARN=permission_boundary,
+    #         synthesize=synth,
+    # )
 
 
 @bootstrap.command(
@@ -85,9 +111,27 @@ def bootstrap_toolchain(
     required=False,
     default=None,
 )
+@click.option(
+    "--synth/--no-synth",
+    type=bool,
+    default=False,
+    help="Synthesize a CFN template only...do not deploy",
+    required=False,
+)
 @click.option("--debug/--no-debug", default=False, help="Enable detail logging", show_default=True)
-def bootstrap_target(project: str, toolchain_account: str, permission_boundary: Optional[str], debug: bool) -> None:
+def bootstrap_target(
+    project: str,
+    toolchain_account: str,
+    permission_boundary: Optional[str],
+    synth: bool,
+    debug: bool = False,
+) -> None:
     if debug:
         enable_debug(format=DEBUG_LOGGING_FORMAT)
     _logger.debug("Bootstrapping a Target account for Project %s", project)
-    pass
+    bootstrap_target_account(
+        toolchain_account_id=toolchain_account,
+        project_name="exampleproj",
+        permissionsBoundaryARN=permission_boundary,
+        synthesize=synth,
+    )

--- a/seedfarmer/commands/__init__.py
+++ b/seedfarmer/commands/__init__.py
@@ -12,6 +12,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+from seedfarmer.commands._bootstrap_commands import bootstrap_target_account, bootstrap_toolchain_account
 from seedfarmer.commands._deployment_commands import apply, destroy
 from seedfarmer.commands._module_commands import deploy_module, destroy_module
 from seedfarmer.commands._parameter_commands import generate_export_env_params
@@ -32,4 +33,6 @@ __all__ = [
     "destroy_module_stack",
     "deploy_seedkit",
     "generate_export_env_params",
+    "bootstrap_toolchain_account",
+    "bootstrap_target_account",
 ]

--- a/seedfarmer/commands/_bootstrap_commands.py
+++ b/seedfarmer/commands/_bootstrap_commands.py
@@ -1,0 +1,97 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License").
+#    You may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+import json
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+import yaml
+from jinja2 import Template
+
+from seedfarmer import CLI_ROOT
+from seedfarmer.utils import CfnSafeYamlLoader
+
+_logger: logging.Logger = logging.getLogger(__name__)
+
+
+def get_toolchain_template(
+    project_name: str,
+    principalARN: List[str],
+    permissionsBoundaryARN: Optional[str] = None,
+) -> Dict[Any, Any]:
+    with open((os.path.join(CLI_ROOT, "resources/toolchain_role.template")), "r") as f:
+        role = yaml.load(f, CfnSafeYamlLoader)
+    if principalARN:
+        role["Resources"]["ToolchainRole"]["Properties"]["AssumeRolePolicyDocument"]["Statement"][0]["Principal"][
+            "AWS"
+        ] = principalARN
+    if permissionsBoundaryARN:
+        role["Resources"]["ToolchainRole"]["Properties"]["PermissionsBoundary"] = permissionsBoundaryARN
+    template = Template(json.dumps(role))
+    t = template.render({"project_name": project_name})
+    return dict(json.loads(t))
+
+
+def get_deployment_template(
+    toolchain_account_id: str, project_name: str, permissionsBoundaryARN: Optional[str] = None
+) -> Dict[Any, Any]:
+    with open((os.path.join(CLI_ROOT, "resources/deployment_role.template")), "r") as f:
+        role = yaml.load(f, CfnSafeYamlLoader)
+    if permissionsBoundaryARN:
+        role["Resources"]["DeploymentRole"]["Properties"]["PermissionsBoundary"] = permissionsBoundaryARN
+    template = Template(json.dumps(role))
+    t = template.render({"toolchain_account_id": toolchain_account_id, "project_name": project_name})
+    return dict(json.loads(t))
+
+
+def write_template(template: Dict[Any, Any], name: str) -> None:
+    loc = os.path.join(os.getcwd(), "templates")
+    output = os.path.join(loc, name)
+    _logger.info(f"Writing template to {output}")
+    os.makedirs(loc, exist_ok=True)
+    with open(output, "w") as outfile:
+        yaml.dump(template, outfile)
+
+
+def bootstrap_toolchain_account(
+    project_name: str,
+    principalARN: List[str],
+    permissionsBoundaryARN: Optional[str] = None,
+    synthesize: bool = False,
+) -> Optional[Dict[Any, Any]]:
+    template = get_toolchain_template(project_name, principalARN, permissionsBoundaryARN)
+    _logger.debug((json.dumps(template, indent=4)))
+    if not synthesize:
+        # call the services to deploy
+        pass
+    else:
+        write_template(template=template, name="toolchain_bootstrap.yaml")
+    return template
+
+
+def bootstrap_target_account(
+    toolchain_account_id: str,
+    project_name: str,
+    permissionsBoundaryARN: Optional[str] = None,
+    synthesize: bool = False,
+) -> Optional[Dict[Any, Any]]:
+    template = get_deployment_template(toolchain_account_id, project_name, permissionsBoundaryARN)
+    _logger.debug((json.dumps(template, indent=4)))
+    if not synthesize:
+        # call the services to deploy
+        pass
+    else:
+        write_template(template=template, name="target_bootstrap.yaml")
+    return template

--- a/seedfarmer/commands/_bootstrap_commands.py
+++ b/seedfarmer/commands/_bootstrap_commands.py
@@ -67,11 +67,11 @@ def write_template(template: Dict[Any, Any], name: str) -> None:
 
 def bootstrap_toolchain_account(
     project_name: str,
-    principalARN: List[str],
+    principalARNs: List[str],
     permissionsBoundaryARN: Optional[str] = None,
     synthesize: bool = False,
 ) -> Optional[Dict[Any, Any]]:
-    template = get_toolchain_template(project_name, principalARN, permissionsBoundaryARN)
+    template = get_toolchain_template(project_name, principalARNs, permissionsBoundaryARN)
     _logger.debug((json.dumps(template, indent=4)))
     if not synthesize:
         # call the services to deploy

--- a/seedfarmer/resources/deployment_role.template
+++ b/seedfarmer/resources/deployment_role.template
@@ -1,0 +1,139 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: AWS CloudFormation for the SeedFarmer Deployment Role
+Outputs:
+  DeploymentRoleName:
+    Value:
+      Ref: DeploymentRole
+Resources:
+  DeploymentRole:
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        -   Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+                AWS: arn:aws:iam::{{ toolchain_account_id }}:role/seedfarmer-{{ project_name }}-toolchain-role
+      Path: /
+      Policies:
+        - PolicyName: InlineToolchain
+          PolicyDocument:
+            Statement:
+            - Action:
+              - kms:Enable*
+              - kms:Get*
+              - kms:Decrypt
+              - kms:Untag*
+              - kms:Put*
+              - kms:List*
+              - kms:Tag*
+              - kms:Encrypt
+              - kms:Describe*
+              - kms:Disable*
+              - kms:Retire*
+              - kms:Update*
+              - kms:Revoke*
+              - kms:Generate*
+              - kms:Delete*
+              - kms:Create*
+              Effect: Allow
+              Resource:
+                - Fn::Join: [
+                    "",[
+                    "arn:aws:kms:*:",
+                    "Ref": AWS::AccountId,
+                    ":key/*"]
+                  ]
+                - Fn::Join: [
+                    "",[
+                    "arn:aws:kms:*:",
+                    "Ref": AWS::AccountId,
+                    ":alias/*"]
+                  ]  
+              Sid: DeploymentKMS
+            - Action:
+              - iam:Delete*
+              - iam:Create*
+              - iam:Get*
+              - iam:Tag*
+              - iam:Untag*
+              - iam:Update*
+              - iam:AttachRolePolicy
+              - iam:PutRolePolicy
+              - iam:Pass*
+              - iam:DetachRolePolicy
+              Effect: Allow
+              Resource:
+                - Fn::Join: [
+                    "",[
+                    "arn:aws:iam::",
+                    "Ref": AWS::AccountId,
+                    ":role/*"]
+                  ]
+                - Fn::Join: [
+                    "",[
+                    "arn:aws:iam::",
+                    "Ref": AWS::AccountId,
+                    ":policy/*"]
+                  ]            
+              Sid: DeploymentIAM
+            - Action:
+              - codebuild:Update*
+              - codebuild:Batch*
+              - codebuild:Create*
+              - codebuild:Delete*
+              Effect: Allow
+              Resource:
+                Fn::Join: [
+                  "",[
+                  "arn:aws:codebuild:*:",
+                  "Ref": AWS::AccountId,
+                  ":project/*"]
+                ]
+              Sid: DeploymentCodeBuild
+            - Action:
+              - iam:ListPolicies
+              - kms:ListKeys
+              - ssm:DescribeParameters
+              - kms:UpdateCustomKeyStore
+              - kms:ListAliases
+              - codebuild:ListProjects
+              Effect: Allow
+              Resource: '*'
+              Sid: DeploymentListStuff
+            - Action:
+              - s3:Delete*
+              - s3:Put*
+              - s3:Get*
+              - s3:Restore*
+              - s3:Create*
+              - s3:List*
+              Effect: Allow
+              Resource:
+              - arn:aws:s3:::{{ project_name }}*/*
+              Sid: DeploymentS3
+            - Action:
+              - sts:AssumeRole
+              - sts:TagSession
+              - sts:GetSessionToken
+              Effect: Allow
+              Resource:
+              - arn:aws:iam::*:role/{{ project_name }}*
+              Sid: DeploymentSTS
+            - Action:
+              - ssm:Put*
+              - ssm:Delete*
+              - ssm:Remove*
+              - ssm:Add*
+              - ssm:Describe*
+              - ssm:Get*
+              Effect: Allow              
+              Resource: 
+                Fn::Join: [
+                  "",[
+                  "arn:aws:ssm:*:",
+                  "Ref": AWS::AccountId,
+                  ":parameter/{{ project_name }}/*"]
+                ]
+      RoleName: seedfarmer-{{ project_name }}-deployment-role
+    Type: AWS::IAM::Role

--- a/seedfarmer/resources/projectpolicy.yaml
+++ b/seedfarmer/resources/projectpolicy.yaml
@@ -1,0 +1,79 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: "This stack deploys Project deployment policy"
+Parameters:
+  ProjectName:
+    Type: String
+    Description: The name of the project
+  DeploymentName:
+    Type: String
+    Description: The name of the deployment
+Resources:
+  ProjectPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Description: Managed Policy granting access to build a project
+      Path: /
+      PolicyDocument:
+        Statement:
+          - Effect: Allow
+            Action:
+              - "cloudformation:Describe*"
+              - "cloudformation:GetTemplate"
+              - "ec2:Describe*"
+              - "ec2:Get*"
+              - "ecr:Describe*"
+              - "ecr:Get*"
+              - "ecr:List*"
+              - "elasticloadbalancing:Describe*"
+              - "iam:Get*"
+              - "iam:List*"
+              - "logs:CreateLogGroup"
+              - "logs:Describe*"
+              - "logs:DescribeLogGroups"
+              - "s3:List*"
+              - 'kms:CreateKey'
+              - 'kms:Describe*'
+              - 'kms:List*'
+              - 'kms:TagResource'
+            Resource: '*'
+          - Effect: Allow
+            Action:
+              - ssm:Get*
+              - ssm:Describe*
+              - ssm:PutParameter
+              - ssm:DeleteParameter
+              - ssm:DeleteParameters
+            Resource:
+              -  !Sub "arn:aws:ssm::${AWS::AccountId}:parameter/${ProjectName}*"
+          - Effect: Allow
+            Action:
+              - logs:CreateLogStream
+              - logs:PutLogEvents
+              - logs:GetLogEvents
+              - logs:GetLogRecord
+              - logs:GetLogGroupFields
+              - logs:GetQueryResults
+            Resource:
+              - !Sub "arn:aws:logs::${AWS::AccountId}:log-group:/aws/codebuild/codeseeder-${ProjectName}*"
+          - Effect: Allow
+            Action:
+              - ssm:GetParameter
+            Resource:
+              -  !Sub "arn:aws:ssm::${AWS::AccountId}:parameter/cdk-bootstrap*"
+          - Effect: Allow
+            Action:
+              - iam:UpdateAssumeRolePolicy
+            Resource:
+              -  !Sub "arn:aws:iam::${AWS::AccountId}:role/${ProjectName}*"
+          - Effect: Allow
+            Action:
+              - "iam:PassRole"
+              - "sts:AssumeRole"
+            Resource:
+              - !Sub "arn:aws:iam::${AWS::AccountId}:role/cdk*"
+        Version: '2012-10-17'
+
+Outputs:
+  ProjectPolicyARN:
+    Value: !Ref 'ProjectPolicy'
+

--- a/seedfarmer/resources/toolchain_role.template
+++ b/seedfarmer/resources/toolchain_role.template
@@ -1,0 +1,47 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: AWS CloudFormation for the SeedFarmer Toolchain Role
+Outputs:
+  ToolchainRoleName:
+    Value:
+      Ref: ToolchainRole
+Resources:
+  ToolchainRole:
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        -   Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+                AWS: []
+      Path: /
+      Policies:
+        - PolicyName: InlineToolchain
+          PolicyDocument:
+            Statement:
+            - Action:
+              - sts:AssumeRole
+              - sts:TagSession
+              - sts:GetSessionToken
+              Effect: Allow
+              Resource:
+              - arn:aws:iam::*:role/seedfarmer-{{ project_name }}*
+              Sid: ToolChainSTS
+            - Action:
+              - ssm:Put*
+              - ssm:Delete*
+              - ssm:Remove*
+              - ssm:Add*
+              - ssm:Describe*
+              - ssm:Get*
+              Effect: Allow
+              Resource: 
+                Fn::Join: [
+                  "",[
+                  "arn:aws:ssm:*:",
+                  "Ref": AWS::AccountId,
+                  ":parameter/{{ project_name }}/*"]
+                ]
+              Sid: ToolChainSSM
+      RoleName: seedfarmer-{{ project_name }}-toolchain-role
+    Type: AWS::IAM::Role


### PR DESCRIPTION
*Issue #, if available:*
#65 
#66 

*Description of changes:*
Adding in support for creating CFN templates for toolchain and target accounts

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
