### PR TITLE
enable envVariable as a valueFrom source

### DIFF
--- a/examples/exampleproject/manifests-multi/examples/deployment.yaml
+++ b/examples/exampleproject/manifests-multi/examples/deployment.yaml
@@ -1,0 +1,26 @@
+name: examples
+toolchainRegion: us-west-2
+groups:
+  - name: optionals
+    path: manifests-multi/examples/optional-modules.yaml
+  - name: optionals-2
+    path: manifests-multi/examples/optional-modules-2.yaml
+targetAccountMappings:
+  - alias: primary
+    accountId:
+      valueFrom:
+        envVariable: PRIMARY_ACCOUNT
+    default: true
+    regionMappings:
+      - region: us-west-2
+        default: true
+      - region: us-east-2
+  - alias: secondary
+    accountId:
+      valueFrom:
+        envVariable: SECONDARY_ACCOUNT
+    default: false
+    regionMappings:
+      - region: us-west-2
+      - region: us-east-2
+        default: true

--- a/examples/exampleproject/manifests-multi/examples/optional-modules-2.yaml
+++ b/examples/exampleproject/manifests-multi/examples/optional-modules-2.yaml
@@ -1,0 +1,20 @@
+name: networking
+path: modules/optionals/networking/
+targetAccount: primary
+parameters:
+  - name: internet-accessible
+    value: true
+---
+name: buckets
+path: modules/optionals/buckets
+targetAccount: secondary
+targetRegion: us-west-2
+parameters:
+  - name: encryption-type
+    value: SSE
+  - name: some-name
+    valueFrom:
+      moduleMetadata:
+        group: optionals
+        name: networking
+        key: VpcId

--- a/examples/exampleproject/manifests-multi/examples/optional-modules.yaml
+++ b/examples/exampleproject/manifests-multi/examples/optional-modules.yaml
@@ -1,0 +1,16 @@
+name: networking
+path: modules/optionals/networking/
+targetAccount: secondary
+parameters:
+  - name: internet-accessible
+    value: true
+---
+name: buckets
+path: modules/optionals/buckets
+targetAccount: primary
+targetRegion: us-east-2
+parameters:
+  - name: encryption-type
+    value: SSE
+  - name: some-name
+    value: other

--- a/examples/exampleproject/manifests/examples/deployment-upgrade.yaml
+++ b/examples/exampleproject/manifests/examples/deployment-upgrade.yaml
@@ -1,0 +1,15 @@
+name: examples
+toolchainRegion: us-west-2
+groups:
+  - name: optionals
+    path: manifests/examples/optional-modules.yaml
+targetAccountMappings:
+  - alias: primary
+    accountId:
+      valueFrom:
+        envVariable: PRIMARY_ACCOUNT
+    default: true
+    regionMappings:
+      - region: us-west-2
+        default: true
+      - region: us-east-2

--- a/examples/exampleproject/manifests/examples/deployment.yaml
+++ b/examples/exampleproject/manifests/examples/deployment.yaml
@@ -1,17 +1,4 @@
 name: examples
-toolchainRegion: us-west-2
 groups:
   - name: optionals
     path: manifests/examples/optional-modules.yaml
-targetAccountMappings:
-  - alias: primary
-    accountId: "000000000000"
-    default: true
-    # parametersGlobal:
-    #   permissionBoundaryArn: "arn:aws:iam::000000000000:policy/policy-name"
-    #   dockerCredentialsSecret: some-secret
-    regionMappings:
-      - region: us-west-2
-        default: true
-        parametersRegional:
-          someKey: someValue

--- a/seedfarmer/__main__.py
+++ b/seedfarmer/__main__.py
@@ -14,9 +14,11 @@
 
 
 import logging
+import os
 from typing import Optional
 
 import click
+from dotenv import load_dotenv
 
 import seedfarmer
 from seedfarmer import DEBUG_LOGGING_FORMAT, commands, config, enable_debug
@@ -25,6 +27,9 @@ from seedfarmer.output_utils import print_bolded
 from seedfarmer.services.session_manager import SessionManager
 
 _logger: logging.Logger = logging.getLogger(__name__)
+
+# Load environment variables from .env file if it exists
+load_dotenv(dotenv_path=os.path.join(config.OPS_ROOT, ".env"), verbose=True, override=True)
 
 
 def _load_project() -> str:

--- a/seedfarmer/commands/_parameter_commands.py
+++ b/seedfarmer/commands/_parameter_commands.py
@@ -12,8 +12,8 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-
 import logging
+import os
 from typing import Any, Dict, List, Optional, Tuple, cast
 
 from seedfarmer import config
@@ -51,6 +51,10 @@ def load_parameter_values(
                 deployment_name, parameter, parameter_values_cache, deployment_manifest
             )
             parameter_values.append(module_metatdata) if module_metatdata else None
+        elif parameter.value_from and parameter.value_from.env_variable:
+            parameter_values.append(
+                ModuleParameter(name=parameter.name, value=os.getenv(parameter.value_from.env_variable, ""))
+            )
     return parameter_values
 
 

--- a/seedfarmer/resources/deployment_role.template
+++ b/seedfarmer/resources/deployment_role.template
@@ -38,8 +38,7 @@ Resources:
               - kms:Create*
               Effect: Allow
               Resource:
-                - Fn::Sub: "arn:aws:kms:*:${AWS::AccountId}:key/*"
-                - Fn::Sub: "arn:aws:kms:*:${AWS::AccountId}:alias/*"
+                - Fn::Sub: "arn:aws:kms:*:${AWS::AccountId}:alias/{{ project_name }}-*"
               Sid: DeploymentKMS
             - Action:
               - iam:Delete*
@@ -55,8 +54,8 @@ Resources:
               - iam:List*
               Effect: Allow
               Resource:
-                - Fn::Sub: "arn:aws:iam::${AWS::AccountId}:role/*"
-                - Fn::Sub: "arn:aws:iam::${AWS::AccountId}:policy/*"
+                - Fn::Sub: "arn:aws:iam::${AWS::AccountId}:role/{{ project_name }}-*"
+                - Fn::Sub: "arn:aws:iam::${AWS::AccountId}:policy/{{ project_name }}-*"
               Sid: DeploymentIAM
             - Action:
               - codebuild:Update*

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
         "checksumdir~=1.2.0",
         "rich~=12.4.0",
         "requests==2.28.1",
+        "python-dotenv~=0.21.0",
     ],
     entry_points={"console_scripts": ["seedfarmer = seedfarmer.__main__:main"]},
     classifiers=[


### PR DESCRIPTION
*Issue #, if available:* closes #106

*Description of changes:*
- enable `envVariable` as a `valueFrom` source for module parameters and targetAccountMapping accountIds

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
