### PR TITLE
adding threading to target account priming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 - bootstrap command support to generate CFN templates for Toolchain and Target accounts
 - added deployment for toolchain and target accounts via CFN
 - support for cross-account and cross-region deployments
-- support for envVariable as valueFrom via .env and python-detenv
+- support for envVariable as valueFrom via .env and python-dotenv
+- threadded the priming of accounts on create and destroy
+- added ddestroy of managed polices when destroying deployments
 
 
 
@@ -25,6 +27,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 - moved projectpolicy.yaml into resources/.
 - added profile and region support for session in `_session_utils.py`
 - convertd `session_manager.py` to only use `_session_utils.py`
+- refactored deployment_command objects and signatures for threadding 
 
 ### Fixes
 - fix import failure of seedfarmer top-level module if seedfarmer.yaml doesn't exist
@@ -32,6 +35,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 - ensure get_account_id() and get_regin() always use correct boto3.Session
 - ensure bootstrap functions look for roles and cfn templates when updating/deploying roles
 - honed back deployment role permissions
+- modified session manager to support threadding with the toolchain session
 
 ## v0.1.4 (2022-08-16)
 

--- a/seedfarmer/__init__.py
+++ b/seedfarmer/__init__.py
@@ -30,7 +30,7 @@ __all__ = ["__description__", "__license__", "__title__"]
 __version__: str = pkg_resources.get_distribution(__title__).version
 
 DEBUG_LOGGING_FORMAT = "[%(asctime)s][%(filename)-13s:%(lineno)3d] %(message)s"
-INFO_LOGGING_FORMAT = "[%(filename)-13s:%(lineno)3d] %(message)s"
+INFO_LOGGING_FORMAT = "[%(asctime)s | %(levelname)s | %(filename)-13s:%(lineno)3d | %(threadName)s ] %(message)s"
 
 CLI_ROOT = os.path.dirname(os.path.abspath(__file__))
 

--- a/seedfarmer/commands/_stack_commands.py
+++ b/seedfarmer/commands/_stack_commands.py
@@ -46,17 +46,13 @@ class StackInfo(object):
 info = StackInfo()
 
 
-def deploy_managed_policy_stack(
-    deployment_name: str, deployment_manifest: DeploymentManifest, account_id: str, region: str
-) -> None:
+def deploy_managed_policy_stack(deployment_manifest: DeploymentManifest, account_id: str, region: str) -> None:
     """
     deploy_managed_policy_stack
         This function deploys the deployment-specific policy to allow CodeSeeder to deploy.
 
     Parameters
     ----------
-    deployment_name : str
-        The name of the deployment
     deployment_manifest : DeploymentManifest
         The DeploymentManifest object of the deploy
     account_id: str
@@ -86,8 +82,8 @@ def deploy_managed_policy_stack(
         services.cfn.deploy_template(
             stack_name=info.PROJECT_MANAGED_POLICY_CFN_NAME,
             filename=project_managed_policy_template,
-            seedkit_tag=deployment_name,
-            parameters={"ProjectName": config.PROJECT.lower(), "DeploymentName": deployment_name},
+            seedkit_tag=deployment_manifest.name,
+            parameters={"ProjectName": config.PROJECT.lower(), "DeploymentName": deployment_manifest.name},
             session=session,
         )
 

--- a/seedfarmer/services/_service_utils.py
+++ b/seedfarmer/services/_service_utils.py
@@ -53,8 +53,15 @@ def boto3_client(
     session: Optional[Session] = None,
     region_name: Optional[str] = None,
     profile: Optional[str] = None,
+    aws_access_key_id: Optional[str] = None,
+    aws_secret_access_key: Optional[str] = None,
+    aws_session_token: Optional[str] = None,
 ) -> boto3.client:
-    if not session:
+    if aws_access_key_id and aws_secret_access_key and aws_session_token:
+        return create_new_session_with_creds(
+            aws_access_key_id, aws_secret_access_key, aws_session_token, region_name
+        ).client(service_name=service_name, use_ssl=True, config=get_botocore_config())
+    elif not session:
         return create_new_session(region_name, profile).client(
             service_name=service_name, use_ssl=True, config=get_botocore_config()
         )

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     keywords=["aws", "cdk"],
     python_requires=">=3.7",
     install_requires=[
-        "aws-codeseeder~=0.5.0",
+        "aws-codeseeder~=0.5.2",
         "cookiecutter~=2.1.0",
         "pyhumps~=3.5.0",
         "pydantic~=1.9.0",


### PR DESCRIPTION
*Issue #, if available:*
#95 

Refactored the deployment process to use threading for priming accounts, refactored session manager to utilize thread-safe sessions toolchain, cleaned up the deploy and destroy thread commands


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
