### PR TITLE
Fix/permissions boundary name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,12 +27,12 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ### Changes
 - update DeploymentManifest to support targetAccountMappings and regionMappings
 - update ModuleManifest to support targetAccount and targetRegion with defaults
-- move deployment level Parameters (dockerCredentialsSecret, permissionBoundaryArn) to mappings
+- move deployment level Parameters (dockerCredentialsSecret, permissionsBoundaryName) to mappings
 - refactor cli commands/groups to reduce line count in `__main__.py`
 - moved projectpolicy.yaml into resources/.
 - added profile and region support for session in `_session_utils.py`
 - convertd `session_manager.py` to only use `_session_utils.py`
-- refactored deployment_command objects and signatures for threadding 
+- refactored deployment_command objects and signatures for threadding
 
 ### Fixes
 - fix import failure of seedfarmer top-level module if seedfarmer.yaml doesn't exist
@@ -41,6 +41,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 - ensure bootstrap functions look for roles and cfn templates when updating/deploying roles
 - honed back deployment role permissions
 - modified session manager to support threadding with the toolchain session
+- rename manifest parameter permissionBoundaryArn -> permissionsBoundaryName to align on AWS naming and hide account ids in ARNs
 
 ## v0.1.4 (2022-08-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 - honed back deployment role permissions
 - modified session manager to support threadding with the toolchain session
 - rename manifest parameter permissionBoundaryArn -> permissionsBoundaryName to align on AWS naming and hide account ids in ARNs
+- ensure we find a deploymed manifest when listing/printing module metadata
 
 ## v0.1.4 (2022-08-16)
 

--- a/docs/source/manifests.md
+++ b/docs/source/manifests.md
@@ -32,14 +32,14 @@ Its elements are:
     }
   }
   ```
-- *permissionBoundaryArn*
+- *permissionsBoundaryName*
   - _OPTIONAL_
   - The value should be the Name of the Permission Boundary Managed Policy
-  - Below is the command to deploy a sample [Permission Boundary](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html) Managed Policy stack located in the project, however we expect the consumer of the framework to create a permission boundary as per their security requirements/guidelines and provide the ARN to the key `permissionBoundaryArn`:
+  - Below is the command to deploy a sample [Permission Boundary](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html) Managed Policy stack located in the project, however we expect the consumer of the framework to create a permission boundary as per their security requirements/guidelines and provide the ARN to the key `permissionsBoundaryName`:
   ```sh
   aws cloudformation deploy \
     --template-file ./resources/sample-permissionboundary.yaml \
-    --stack-name permission-boundary-stack \
+    --stack-name permissions-boundary-stack \
     --parameter-overrides ManagedPolicyName=MyAppPermissionBoundary \
     --capabilities CAPABILITY_NAMED_IAM
   ```
@@ -55,7 +55,7 @@ groups:
     path: manifests/example-dev/core-modules.yaml
 projectPolicy: resources/mycustomiampolicy.yaml
 dockerCredentialsSecret: aws-myapp-docker-credentials
-permissionBoundaryArn: arn:aws:iam::XXXXXXXXXXXX:policy/MyAppPermissionBoundary
+permissionsBoundaryName: MyAppPermissionBoundary
 ```
 (module_manifest)=
 ### Module Manifest

--- a/docs/source/resources.md
+++ b/docs/source/resources.md
@@ -6,7 +6,7 @@ The resources section/directory of the [project stucture](project_structure.md) 
 ### Project Policy
 `SeedFarmer` expects a policy located at `resources/projectpolicy.yaml`.  This provided by default when using the [project initialization](cookiecutter_new_project).  This can be used as-is, modified, or you can provide your own - but this policy contains the MINIMUM permissions `SeedFarmer` needs to operate.
 
-(permission_boundary)=
+(permissions_boundary)=
 ### Permission Boundary Support
 `SeedFarmer` supports the concept of a [permission boundary](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html).  This should already be deployed in your AWS account prior to use.
 

--- a/seedfarmer/cli_groups/_bootstrap_group.py
+++ b/seedfarmer/cli_groups/_bootstrap_group.py
@@ -60,7 +60,7 @@ def bootstrap() -> None:
     default=[],
 )
 @click.option(
-    "--permission-boundary",
+    "--permissions-boundary",
     "-b",
     help="ARN of a Managed Policy to set as the Permission Boundary on the Toolchain Role",
     required=False,
@@ -98,7 +98,7 @@ def bootstrap() -> None:
 def bootstrap_toolchain(
     project: Optional[str],
     trusted_principal: List[str],
-    permission_boundary: Optional[str],
+    permissions_boundary: Optional[str],
     profile: Optional[str],
     region: Optional[str],
     as_target: bool,
@@ -113,7 +113,7 @@ def bootstrap_toolchain(
     bootstrap_toolchain_account(
         project_name=project,
         principal_arns=trusted_principal,
-        permissions_boundary_arn=permission_boundary,
+        permissions_boundary_arn=permissions_boundary,
         profile=profile,
         region_name=region,
         synthesize=synth,
@@ -139,7 +139,7 @@ def bootstrap_toolchain(
     help="Account Id of the Toolchain account trusted to assume the Target account's Deployment Role",
 )
 @click.option(
-    "--permission-boundary",
+    "--permissions-boundary",
     "-b",
     help="ARN of a Managed Policy to set as the Permission Boundary on the Toolchain Role",
     required=False,
@@ -169,7 +169,7 @@ def bootstrap_toolchain(
 def bootstrap_target(
     project: Optional[str],
     toolchain_account: str,
-    permission_boundary: Optional[str],
+    permissions_boundary: Optional[str],
     profile: Optional[str],
     region: Optional[str],
     synth: bool,
@@ -185,6 +185,6 @@ def bootstrap_target(
         project_name=project,
         profile=profile,
         region_name=region,
-        permissions_boundary_arn=permission_boundary,
+        permissions_boundary_arn=permissions_boundary,
         synthesize=synth,
     )

--- a/seedfarmer/cli_groups/_list_group.py
+++ b/seedfarmer/cli_groups/_list_group.py
@@ -108,7 +108,12 @@ def list_deployspec(
 
     session = SessionManager().get_or_create(project_name=project, profile=profile, region_name=region)
     dep_manifest = du.generate_deployed_manifest(deployment_name=deployment, skip_deploy_spec=True)
-    dep_manifest.validate_and_set_module_defaults() if dep_manifest else None
+
+    if dep_manifest is None:
+        print_json({})
+        return
+
+    dep_manifest.validate_and_set_module_defaults()
     session = session.get_deployment_session(
         account_id=dep_manifest.get_module(group=group, module=module).get_target_account_id(),  # type: ignore
         region_name=dep_manifest.get_module(group=group, module=module).target_region,  # type: ignore
@@ -190,7 +195,14 @@ def list_module_metadata(
 
     session = SessionManager().get_or_create(project_name=project, profile=profile, region_name=region)
     dep_manifest = du.generate_deployed_manifest(deployment_name=deployment, skip_deploy_spec=True)
-    dep_manifest.validate_and_set_module_defaults() if dep_manifest else None
+
+    if dep_manifest is None:
+        print(f"No module data found for {deployment}-{group}-{module}")
+        print_bolded("To see all deployments, run seedfarmer list deployments")
+        print_bolded(f"To see all deployed modules in {deployment}, run seedfarmer list modules -d {deployment}")
+        return
+
+    dep_manifest.validate_and_set_module_defaults()
     session = session.get_deployment_session(
         account_id=dep_manifest.get_module(group=group, module=module).get_target_account_id(),  # type: ignore
         region_name=dep_manifest.get_module(group=group, module=module).target_region,  # type: ignore

--- a/seedfarmer/commands/_module_commands.py
+++ b/seedfarmer/commands/_module_commands.py
@@ -44,7 +44,7 @@ def _env_vars(
     parameters: Optional[List[ModuleParameter]] = None,
     module_metadata: Optional[str] = None,
     docker_credentials_secret: Optional[str] = None,
-    permission_boundary_arn: Optional[str] = None,
+    permissions_boundary_arn: Optional[str] = None,
     session: Optional[Session] = None,
 ) -> Dict[str, str]:
     env_vars = (
@@ -64,8 +64,8 @@ def _env_vars(
     env_vars[_param("HASH")] = generate_hash(session=session)
     if docker_credentials_secret:
         env_vars["AWS_CODESEEDER_DOCKER_SECRET"] = docker_credentials_secret
-    if permission_boundary_arn:
-        env_vars[_param("PERMISSION_BOUNDARY_ARN")] = permission_boundary_arn
+    if permissions_boundary_arn:
+        env_vars[_param("PERMISSIONS_BOUNDARY_ARN")] = permissions_boundary_arn
     return env_vars
 
 
@@ -81,7 +81,7 @@ def deploy_module(
     module_metadata: Optional[str] = None,
     module_bundle_md5: Optional[str] = None,
     docker_credentials_secret: Optional[str] = None,
-    permission_boundary_arn: Optional[str] = None,
+    permissions_boundary_arn: Optional[str] = None,
 ) -> ModuleDeploymentResponse:
     env_vars = _env_vars(
         deployment_name=deployment_name,
@@ -90,7 +90,7 @@ def deploy_module(
         parameters=parameters,
         module_metadata=module_metadata,
         docker_credentials_secret=docker_credentials_secret,
-        permission_boundary_arn=permission_boundary_arn,
+        permissions_boundary_arn=permissions_boundary_arn,
         session=SessionManager().get_or_create().get_deployment_session(account_id=account_id, region_name=region),
     )
     env_vars[_param("MODULE_MD5")] = module_bundle_md5 if module_bundle_md5 is not None else ""

--- a/seedfarmer/commands/_stack_commands.py
+++ b/seedfarmer/commands/_stack_commands.py
@@ -190,7 +190,7 @@ def deploy_module_stack(
     region: str,
     parameters: List[ModuleParameter],
     docker_credentials_secret: Optional[str] = None,
-    permission_boundary_arn: Optional[str] = None,
+    permissions_boundary_arn: Optional[str] = None,
 ) -> None:
     """
     deploy_module_stack
@@ -215,8 +215,8 @@ def deploy_module_stack(
         The region where the module is deployed
     docker_credentials_secret: str
         OPTIONAL parameter with name of SecrestManager of docker credentials
-    permission_boundary_arn: str
-        OPTIONAL parameter with ARN of PermissionBoundary ManagedPolicy
+    permissions_boundary_arn: str
+        OPTIONAL parameter with Name of PermissionBoundary ManagedPolicy
     """
 
     if module_stack_path:
@@ -235,7 +235,7 @@ def deploy_module_stack(
         ],
     }
 
-    iam.create_check_iam_role(trust_policy, module_role_name, permission_boundary_arn, session=session)
+    iam.create_check_iam_role(trust_policy, module_role_name, permissions_boundary_arn, session=session)
 
     group_module_name = f"{group_name}-{module_name}"
 

--- a/seedfarmer/services/_iam.py
+++ b/seedfarmer/services/_iam.py
@@ -36,7 +36,7 @@ def get_role(role_name: str, session: Optional[Session] = None) -> Optional[Dict
 def create_check_iam_role(
     trust_policy: Dict[str, Any],
     role_name: str,
-    permission_boundary_arn: Optional[str],
+    permissions_boundary_arn: Optional[str],
     session: Optional[Session] = None,
 ) -> None:
     _logger.debug("Creating IAM Role with name: %s ", role_name)
@@ -50,8 +50,8 @@ def create_check_iam_role(
             "Description": f"deployment-role for {role_name}",
             "Tags": [{"Key": "Region", "Value": get_region(session=session)}],
         }
-        if permission_boundary_arn:
-            args["PermissionsBoundary"] = permission_boundary_arn
+        if permissions_boundary_arn:
+            args["PermissionsBoundary"] = permissions_boundary_arn
         iam_client.create_role(**args)
 
 

--- a/test/unit-test/mock_data/manifests/module-test/deployment.yaml
+++ b/test/unit-test/mock_data/manifests/module-test/deployment.yaml
@@ -8,7 +8,7 @@ targetAccountMappings:
     accountId: "000000000000"
     default: true
     # parametersGlobal:
-    #   permissionBoundaryArn: "arn:aws:iam::000000000000:policy/policy-name"
+    #   permissionsBoundaryName: policy-name
     #   dockerCredentialsSecret: some-secret
     regionMappings:
       - region: us-west-2

--- a/test/unit-test/mock_data/manifests/test-broken-deployspec-deploy/deployment.yaml
+++ b/test/unit-test/mock_data/manifests/test-broken-deployspec-deploy/deployment.yaml
@@ -8,7 +8,7 @@ targetAccountMappings:
     accountId: "000000000000"
     default: true
     # parametersGlobal:
-    #   permissionBoundaryArn: "arn:aws:iam::000000000000:policy/policy-name"
+    #   permissionsBoundaryName: policy-name
     #   dockerCredentialsSecret: some-secret
     regionMappings:
       - region: us-west-2

--- a/test/unit-test/mock_data/manifests/test-broken-deployspec-destroy/deployment.yaml
+++ b/test/unit-test/mock_data/manifests/test-broken-deployspec-destroy/deployment.yaml
@@ -8,7 +8,7 @@ targetAccountMappings:
     accountId: "000000000000"
     default: true
     # parametersGlobal:
-    #   permissionBoundaryArn: "arn:aws:iam::000000000000:policy/policy-name"
+    #   permissionsBoundaryName: policy-name
     #   dockerCredentialsSecret: some-secret
     regionMappings:
       - region: us-west-2

--- a/test/unit-test/mock_data/manifests/test-missing-deployment-group-name/deployment.yaml
+++ b/test/unit-test/mock_data/manifests/test-missing-deployment-group-name/deployment.yaml
@@ -1,14 +1,14 @@
 name: test-missing-deployment-group-name
 toolchainRegion: us-west-2
 groups:
-  - name: 
+  - name:
     path: manifests/test-missing-deployment-group-name/test-module.yaml
 targetAccountMappings:
   - alias: primary
     accountId: "000000000000"
     default: true
     # parametersGlobal:
-    #   permissionBoundaryArn: "arn:aws:iam::000000000000:policy/policy-name"
+    #   permissionsBoundaryName: policy-name
     #   dockerCredentialsSecret: some-secret
     regionMappings:
       - region: us-west-2

--- a/test/unit-test/mock_data/manifests/test-missing-deployment-group-path/deployment.yaml
+++ b/test/unit-test/mock_data/manifests/test-missing-deployment-group-path/deployment.yaml
@@ -2,13 +2,13 @@ name: test-missing-deployment-group-path
 toolchainRegion: us-west-2
 groups:
   - name: test-missing-path
-    path: 
+    path:
 targetAccountMappings:
   - alias: primary
     accountId: "000000000000"
     default: true
     # parametersGlobal:
-    #   permissionBoundaryArn: "arn:aws:iam::000000000000:policy/policy-name"
+    #   permissionsBoundaryName: policy-name
     #   dockerCredentialsSecret: some-secret
     regionMappings:
       - region: us-west-2

--- a/test/unit-test/mock_data/manifests/test-missing-deployment-name/deployment.yaml
+++ b/test/unit-test/mock_data/manifests/test-missing-deployment-name/deployment.yaml
@@ -8,7 +8,7 @@ targetAccountMappings:
     accountId: "000000000000"
     default: true
     # parametersGlobal:
-    #   permissionBoundaryArn: "arn:aws:iam::000000000000:policy/policy-name"
+    #   permissionsBoundaryName: policy-name
     #   dockerCredentialsSecret: some-secret
     regionMappings:
       - region: us-west-2

--- a/test/unit-test/mock_data/manifests/test-missing-group-manifest/deployment.yaml
+++ b/test/unit-test/mock_data/manifests/test-missing-group-manifest/deployment.yaml
@@ -8,7 +8,7 @@ targetAccountMappings:
     accountId: "000000000000"
     default: true
     # parametersGlobal:
-    #   permissionBoundaryArn: "arn:aws:iam::000000000000:policy/policy-name"
+    #   permissionsBoundaryName: policy-name
     #   dockerCredentialsSecret: some-secret
     regionMappings:
       - region: us-west-2

--- a/test/unit-test/test_models.py
+++ b/test/unit-test/test_models.py
@@ -43,7 +43,7 @@ targetAccountMappings:
     accountId: "000000000000"
     default: true
     parametersGlobal:
-      permissionBoundaryArn: arn
+      permissionsBoundaryName: policyName
       dockerCredentialsSecret: secret
     regionMappings:
       - region: us-west-2


### PR DESCRIPTION
*Issue #, if available:* closes #124, closes #126

*Description of changes:*
- rename manifest parameter `permissionBoundaryArn` -> `permissionsBoundaryName`
   this is done to eliminate committing Account Ids that would be included in ARNs and to align to AWS IAM naming (Permissions not Permission)
- fix None check on deployed manifest when listing/printing module metadata


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
