### PR TITLE
feat: nameGenerator for dynamic deployment names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ## Unreleased
 
 ### New
+- new `generateName` attribute on DeploymentManifest for dynamic creation of the deployment `name`
+
 ### Changes
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ### Changes
 
 ### Fixes
+- unable to destroy when module sourced from remote git repository 
+
 
 ## v2.2.1 (2022-10-25)
 

--- a/seedfarmer/commands/_deployment_commands.py
+++ b/seedfarmer/commands/_deployment_commands.py
@@ -158,6 +158,7 @@ def _execute_deploy(
 def _execute_destroy(
     group_name: str,
     module_manifest: ModuleManifest,
+    module_path: str,
     deployment_manifest: DeploymentManifest,
     docker_credentials_secret: Optional[str] = None,
 ) -> Optional[ModuleDeploymentResponse]:
@@ -169,7 +170,7 @@ def _execute_destroy(
     resp = commands.destroy_module(
         deployment_name=cast(str, deployment_manifest.name),
         group_name=group_name,
-        module_path=module_manifest.path,
+        module_path=module_path,
         module_deploy_spec=module_manifest.deploy_spec,
         module_manifest_name=module_manifest.name,
         account_id=cast(str, module_manifest.get_target_account_id()),
@@ -366,6 +367,9 @@ def destroy_deployment(
                         {
                             "group_name": _group.name,
                             "module_manifest": _module,
+                            "module_path": _clone_module_repo(_module.path)
+                            if _module.path.startswith("git::")
+                            else _module.path,
                             "deployment_manifest": destroy_manifest,
                             "docker_credentials_secret": destroy_manifest.get_parameter_value(
                                 "dockerCredentialsSecret",

--- a/seedfarmer/commands/_deployment_commands.py
+++ b/seedfarmer/commands/_deployment_commands.py
@@ -106,7 +106,7 @@ def _execute_deploy(
     permissions_boundary_arn: Optional[str] = None,
 ) -> ModuleDeploymentResponse:
     parameters = load_parameter_values(
-        deployment_name=deployment_manifest.name,
+        deployment_name=cast(str, deployment_manifest.name),
         parameters=module_manifest.parameters,
         deployment_manifest=deployment_manifest,
     )
@@ -116,7 +116,7 @@ def _execute_deploy(
     # Deploys the IAM role per module
     commands.deploy_module_stack(
         get_modulestack_path(module_manifest.path),
-        deployment_manifest.name,
+        cast(str, deployment_manifest.name),
         group_name,
         module_manifest.name,
         target_account_id,
@@ -131,7 +131,7 @@ def _execute_deploy(
         SessionManager().get_or_create().get_deployment_session(account_id=target_account_id, region_name=target_region)
     )
     module_metadata = json.dumps(
-        get_module_metadata(deployment_manifest.name, group_name, module_manifest.name, session=session)
+        get_module_metadata(cast(str, deployment_manifest.name), group_name, module_manifest.name, session=session)
     )
 
     if module_manifest.deploy_spec is None:
@@ -140,7 +140,7 @@ def _execute_deploy(
         )
 
     return commands.deploy_module(
-        deployment_name=deployment_manifest.name,
+        deployment_name=cast(str, deployment_manifest.name),
         group_name=group_name,
         module_path=os.path.join(config.OPS_ROOT, module_manifest.path),
         module_deploy_spec=module_manifest.deploy_spec,
@@ -167,7 +167,7 @@ def _execute_destroy(
         )
 
     resp = commands.destroy_module(
-        deployment_name=deployment_manifest.name,
+        deployment_name=cast(str, deployment_manifest.name),
         group_name=group_name,
         module_path=module_manifest.path,
         module_deploy_spec=module_manifest.deploy_spec,
@@ -175,7 +175,7 @@ def _execute_destroy(
         account_id=cast(str, module_manifest.get_target_account_id()),
         region=cast(str, module_manifest.target_region),
         parameters=load_parameter_values(
-            deployment_name=deployment_manifest.name,
+            deployment_name=cast(str, deployment_manifest.name),
             parameters=module_manifest.parameters,
             deployment_manifest=deployment_manifest,
         ),
@@ -184,7 +184,7 @@ def _execute_destroy(
 
     if resp.status == StatusType.SUCCESS.value:
         commands.destroy_module_stack(
-            deployment_manifest.name,
+            cast(str, deployment_manifest.name),
             group_name,
             module_manifest.name,
             account_id=cast(str, module_manifest.get_target_account_id()),
@@ -348,7 +348,7 @@ def destroy_deployment(
         return
     print_manifest_inventory(f"Modules removed from manifest: {destroy_manifest.name}", destroy_manifest, False, "red")
 
-    deployment_name = destroy_manifest.name
+    deployment_name = cast(str, destroy_manifest.name)
 
     print_manifest_inventory(
         f"Modules scheduled to be destroyed for: {destroy_manifest.name}", destroy_manifest, False, "red"
@@ -422,7 +422,7 @@ def deploy_deployment(
         By default False
     """
     deployment_manifest_wip = deployment_manifest.copy()
-    deployment_name = deployment_manifest_wip.name
+    deployment_name = cast(str, deployment_manifest_wip.name)
     _logger.debug("Setting up deployment for %s", deployment_name)
 
     print_manifest_inventory(
@@ -556,7 +556,7 @@ def apply(
     )
     if not dryrun:
         write_deployment_manifest(
-            deployment_manifest.name, deployment_manifest.dict(), session=session_manager.toolchain_session
+            cast(str, deployment_manifest.name), deployment_manifest.dict(), session=session_manager.toolchain_session
         )
 
     for module_group in deployment_manifest.groups:

--- a/seedfarmer/mgmt/deploy_utils.py
+++ b/seedfarmer/mgmt/deploy_utils.py
@@ -97,7 +97,7 @@ def populate_module_info_index(deployment_manifest: DeploymentManifest) -> Modul
                 .get_or_create()
                 .get_deployment_session(account_id=args["account_id"], region_name=args["region"])
             )
-            module_info = mi.get_parameter_data_cache(deployment=deployment_manifest.name, session=session)
+            module_info = mi.get_parameter_data_cache(deployment=cast(str, deployment_manifest.name), session=session)
             for key, value in module_info.items():
                 key_parts = key.split("/")[1:]
                 if len(key_parts) < 4:
@@ -127,7 +127,7 @@ def write_deployed_deployment_manifest(deployment_manifest: DeploymentManifest) 
     deployment_manifest : DeploymentManifest
         The deployment manifest ojject to store
     """
-    deployment_name = deployment_manifest.name
+    deployment_name = cast(str, deployment_manifest.name)
     for group in deployment_manifest.groups:
         delattr(group, "modules")
     session = SessionManager().get_or_create().toolchain_session
@@ -292,7 +292,7 @@ def filter_deploy_destroy(apply_manifest: DeploymentManifest, module_info_index:
     DeploymentManifest
         A populated DeploymentManifest object with the modules needed to be destroyed
     """
-    deployment_name = apply_manifest.name
+    deployment_name = cast(str, apply_manifest.name)
 
     destroy_manifest = apply_manifest.copy()
     delattr(destroy_manifest, "groups")

--- a/seedfarmer/models/manifests.py
+++ b/seedfarmer/models/manifests.py
@@ -233,10 +233,7 @@ class NameGenerator(CamelModel):
                 env_value = os.getenv(value.value_from.env_variable, None)
                 if env_value is None:
                     raise ValueError(
-                        (
-                            "Unable to resolve value from Environment Variable:"
-                            f" {value.value_from.env_variable}"
-                        )
+                        ("Unable to resolve value from Environment Variable:" f" {value.value_from.env_variable}")
                     )
                 return env_value
             else:
@@ -244,7 +241,7 @@ class NameGenerator(CamelModel):
         else:
             raise ValueError("Unsupported value type")
 
-    def generate_name(self):
+    def generate_name(self) -> str:
         prefix = self._get_value(self.prefix)
         suffix = self._get_value(self.suffix)
 

--- a/test/unit-test/test_cli_arg.py
+++ b/test/unit-test/test_cli_arg.py
@@ -67,8 +67,7 @@ def test_init_create_group_module():
         sub_command=init, options=["module", "-g", group_name, "-m", module_name], exit_code=1, return_result=True
     )
     assert (
-        result.exception.args[0]
-        == f"The module {module_name} already exists under {_OPS_ROOT}/modules/{group_name}."
+        result.exception.args[0] == f"The module {module_name} already exists under {_OPS_ROOT}/modules/{group_name}."
     )
 
     # Checks if a file from the project template was created within the new module
@@ -84,9 +83,7 @@ def test_init_create_project():
 
     # Creates a project that already exist
     result = _test_command(sub_command=init, options=["project"], exit_code=1, return_result=True)
-    assert (
-        result.exception.args[0] == f'Error: "{os.path.join(_OPS_ROOT, _PROJECT)}" directory already exists'
-    )
+    assert result.exception.args[0] == f'Error: "{os.path.join(_OPS_ROOT, _PROJECT)}" directory already exists'
 
     # Checks if file exists from the project template
     assert os.path.exists(os.path.join(expected_project_path, "seedfarmer.yaml"))

--- a/test/unit-test/test_models.py
+++ b/test/unit-test/test_models.py
@@ -114,7 +114,7 @@ def test_deployment_manifest_name_generator():
     os.environ.setdefault("PYTEST_MODEL_USER", "TESTUSER")
 
     generator_yaml = yaml.safe_load(
-    """
+        """
 nameGenerator:
   prefix: test-
   suffix:
@@ -131,7 +131,7 @@ targetAccountMappings: []
     assert deployment_manifest.name_generator is None
 
     generator_yaml = yaml.safe_load(
-    """
+        """
 nameGenerator:
   prefix:
     valueFrom:
@@ -148,7 +148,7 @@ targetAccountMappings: []
     assert deployment_manifest.name_generator is None
 
     generator_yaml = yaml.safe_load(
-    """
+        """
 name: test-name
 nameGenerator:
   prefix: test
@@ -164,7 +164,7 @@ targetAccountMappings: []
     assert str(e.value) == "Only one of 'name' or 'name_generator' can be specified"
 
     generator_yaml = yaml.safe_load(
-    """
+        """
 toolchainRegion: us-west-2
 groups: []
 targetAccountMappings: []
@@ -176,7 +176,7 @@ targetAccountMappings: []
     assert str(e.value) == "One of 'name' or 'name_generator' is required"
 
     generator_yaml = yaml.safe_load(
-    """
+        """
 nameGenerator:
   prefix: test-
   suffix:
@@ -195,7 +195,7 @@ targetAccountMappings: []
     assert str(e.value) == "Loading value from Module Metadata is not supported on a NameGenerator"
 
     generator_yaml = yaml.safe_load(
-    """
+        """
 nameGenerator:
   prefix: test-
   suffix:

--- a/test/unit-test/test_models.py
+++ b/test/unit-test/test_models.py
@@ -13,6 +13,7 @@
 #    limitations under the License.
 
 import logging
+import os
 from copy import deepcopy
 
 import pytest
@@ -105,6 +106,110 @@ def test_deployment_manifest_get_parameter_without_defaults():
     assert manifest.get_parameter_value("dockerCredentialsSecret") is None
     assert manifest.default_target_account_mapping is None
     assert manifest.target_account_mappings[0].default_region_mapping is None
+
+
+@pytest.mark.models
+@pytest.mark.models_deployment_manifest
+def test_deployment_manifest_name_generator():
+    os.environ.setdefault("PYTEST_MODEL_USER", "TESTUSER")
+
+    generator_yaml = yaml.safe_load(
+    """
+nameGenerator:
+  prefix: test-
+  suffix:
+    valueFrom:
+      envVariable: PYTEST_MODEL_USER
+toolchainRegion: us-west-2
+groups: []
+targetAccountMappings: []
+"""
+    )
+
+    deployment_manifest = DeploymentManifest(**generator_yaml)
+    assert deployment_manifest.name == "test-TESTUSER"
+    assert deployment_manifest.name_generator is None
+
+    generator_yaml = yaml.safe_load(
+    """
+nameGenerator:
+  prefix:
+    valueFrom:
+      envVariable: PYTEST_MODEL_USER
+  suffix: -test
+toolchainRegion: us-west-2
+groups: []
+targetAccountMappings: []
+"""
+    )
+
+    deployment_manifest = DeploymentManifest(**generator_yaml)
+    assert deployment_manifest.name == "TESTUSER-test"
+    assert deployment_manifest.name_generator is None
+
+    generator_yaml = yaml.safe_load(
+    """
+name: test-name
+nameGenerator:
+  prefix: test
+  suffix: -test
+toolchainRegion: us-west-2
+groups: []
+targetAccountMappings: []
+"""
+    )
+
+    with pytest.raises(ValueError) as e:
+        deployment_manifest = DeploymentManifest(**generator_yaml)
+    assert str(e.value) == "Only one of 'name' or 'name_generator' can be specified"
+
+    generator_yaml = yaml.safe_load(
+    """
+toolchainRegion: us-west-2
+groups: []
+targetAccountMappings: []
+"""
+    )
+
+    with pytest.raises(ValueError) as e:
+        deployment_manifest = DeploymentManifest(**generator_yaml)
+    assert str(e.value) == "One of 'name' or 'name_generator' is required"
+
+    generator_yaml = yaml.safe_load(
+    """
+nameGenerator:
+  prefix: test-
+  suffix:
+    valueFrom:
+      moduleMetadata:
+        group: none
+        name: none
+toolchainRegion: us-west-2
+groups: []
+targetAccountMappings: []
+"""
+    )
+
+    with pytest.raises(ValueError) as e:
+        deployment_manifest = DeploymentManifest(**generator_yaml)
+    assert str(e.value) == "Loading value from Module Metadata is not supported on a NameGenerator"
+
+    generator_yaml = yaml.safe_load(
+    """
+nameGenerator:
+  prefix: test-
+  suffix:
+    valueFrom:
+      envVariable: PYTEST_NO_VAR
+toolchainRegion: us-west-2
+groups: []
+targetAccountMappings: []
+"""
+    )
+
+    with pytest.raises(ValueError) as e:
+        deployment_manifest = DeploymentManifest(**generator_yaml)
+    assert str(e.value) == "Unable to resolve value from Environment Variable: PYTEST_NO_VAR"
 
 
 @pytest.mark.models


### PR DESCRIPTION
*Issue #, if available:* closes #169

*Description of changes:*
- new `nameGenerator` attribute for dynamic creation of deployment names from `envVariable`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
