### PR TITLE
fix: test error message when deployment name is missing

### DIFF
--- a/test/unit-test/test_cli_arg.py
+++ b/test/unit-test/test_cli_arg.py
@@ -150,7 +150,7 @@ def test_apply_missing_deployment_name():
     deployment_manifest = f"{_TEST_ROOT}/manifests/test-missing-deployment-name/deployment.yaml"
 
     result = _test_command(sub_command=apply, options=deployment_manifest, exit_code=1, return_result=True)
-    assert result.exception.args[0][0].exc.msg_template == "none is not an allowed value"
+    assert result.exception.args[0] == "One of 'name' or 'name_generator' is required"
 
 
 @pytest.mark.apply


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*
- pytest when the deployment name is missing

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
