### PR TITLE
feat: --enable-session-timeout and --session-timeout-interval CLI params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ### New
 - new `generateName` attribute on DeploymentManifest for dynamic creation of the deployment `name`
 - added documentation for git sourcing of modules
+- new --enable-session-timeout and --session-timeout-interval CLI options on apply and destroy
 
 ### Changes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ exclude = '''
   | build
   | dist
   | codeseeder.out
+  | seedfarmer.gitmodules
 )/
 '''
 

--- a/seedfarmer/__main__.py
+++ b/seedfarmer/__main__.py
@@ -68,18 +68,35 @@ def version() -> None:
     default=False,
     help="Enable detailed logging.",
     show_default=True,
+    type=bool,
 )
 @click.option(
     "--dry-run/--no-dry-run",
     default=False,
     help="Apply but do not execute....",
     show_default=True,
+    type=bool,
 )
 @click.option(
     "--show-manifest/--no-show-manifest",
     default=False,
     help="Write out the generated deployment manifest",
     show_default=True,
+    type=bool,
+)
+@click.option(
+    "--enable-session-timeout/--disable-session-timeout",
+    default=False,
+    help="Enable boto3 Session timeouts. If enabled, boto3 Sessions will be reset on the timeout interval",
+    show_default=True,
+    type=bool,
+)
+@click.option(
+    "--session-timeout-interval",
+    default=900,
+    help="If --enable-session-timeout, the interval, in seconds, to reset boto3 Sessions",
+    show_default=True,
+    type=int,
 )
 def apply(
     spec: str,
@@ -89,6 +106,8 @@ def apply(
     debug: bool,
     dry_run: bool,
     show_manifest: bool,
+    enable_session_timeout: bool,
+    session_timeout_interval: int,
 ) -> None:
     """Apply manifests to a SeedFarmer managed deployment"""
     if debug:
@@ -102,7 +121,13 @@ def apply(
         print_bolded(" ***   This is a dry-run...NO ACTIONS WILL BE TAKEN  *** ", "white")
 
     commands.apply(
-        deployment_manifest_path=spec, profile=profile, region_name=region, dryrun=dry_run, show_manifest=show_manifest
+        deployment_manifest_path=spec,
+        profile=profile,
+        region_name=region,
+        dryrun=dry_run,
+        show_manifest=show_manifest,
+        enable_session_timeout=enable_session_timeout,
+        session_timeout_interval=session_timeout_interval,
     )
 
 
@@ -148,6 +173,20 @@ def apply(
     help="Enable detailed logging.",
     show_default=True,
 )
+@click.option(
+    "--enable-session-timeout/--disable-session-timeout",
+    default=False,
+    help="Enable boto3 Session timeouts. If enabled, boto3 Sessions will be reset on the timeout interval",
+    show_default=True,
+    type=bool,
+)
+@click.option(
+    "--session-timeout-interval",
+    default=900,
+    help="If --enable-session-timeout, the interval, in seconds, to reset boto3 Sessions",
+    show_default=True,
+    type=int,
+)
 def destroy(
     deployment: str,
     dry_run: bool,
@@ -156,6 +195,8 @@ def destroy(
     region: Optional[str],
     env_file: str,
     debug: bool,
+    enable_session_timeout: bool,
+    session_timeout_interval: int,
 ) -> None:
     """Destroy a SeedFarmer managed deployment"""
     if debug:
@@ -173,7 +214,13 @@ def destroy(
         print_bolded(" ***   This is a dry-run...NO ACTIONS WILL BE TAKEN  *** ", "white")
 
     commands.destroy(
-        deployment_name=deployment, profile=profile, region_name=region, dryrun=dry_run, show_manifest=show_manifest
+        deployment_name=deployment,
+        profile=profile,
+        region_name=region,
+        dryrun=dry_run,
+        show_manifest=show_manifest,
+        enable_session_timeout=enable_session_timeout,
+        session_timeout_interval=session_timeout_interval,
     )
 
 

--- a/seedfarmer/commands/_deployment_commands.py
+++ b/seedfarmer/commands/_deployment_commands.py
@@ -509,6 +509,8 @@ def apply(
     region_name: Optional[str] = None,
     dryrun: bool = False,
     show_manifest: bool = False,
+    enable_session_timeout: bool = False,
+    session_timeout_interval: int = 900,
 ) -> None:
     """
     apply
@@ -535,6 +537,10 @@ def apply(
         This flag indicates to print out the DeploymentManifest object as s dictionary.
 
         By default False
+    enable_session_timeout: bool
+        If enabled, boto3 Sessions will be reset on the timeout interval
+    session_timeout_interval: int
+        The interval, in seconds, to reset boto3 Sessions
 
     Raises
     ------
@@ -551,7 +557,11 @@ def apply(
 
     # Initialize the SessionManager for the entire project
     session_manager = SessionManager().get_or_create(
-        project_name=config.PROJECT, profile=profile, region_name=region_name
+        project_name=config.PROJECT,
+        profile=profile,
+        region_name=region_name,
+        enable_reaper=enable_session_timeout,
+        reaper_interval=session_timeout_interval,
     )
     if not dryrun:
         write_deployment_manifest(
@@ -596,6 +606,8 @@ def destroy(
     dryrun: bool = False,
     show_manifest: bool = False,
     retain_seedkit: bool = False,
+    enable_session_timeout: bool = False,
+    session_timeout_interval: int = 900,
 ) -> None:
     """
     destroy
@@ -618,11 +630,22 @@ def destroy(
         This flag indicates to print out the DeploymentManifest object as s dictionary.
 
         By default False
+    enable_session_timeout: bool
+        If enabled, boto3 Sessions will be reset on the timeout interval
+    session_timeout_interval: int
+        The interval, in seconds, to reset boto3 Sessions
+
 
     """
     project = config.PROJECT
     _logger.debug("Preparing to destroy %s", deployment_name)
-    SessionManager().get_or_create(project_name=project, profile=profile, region_name=region_name)
+    SessionManager().get_or_create(
+        project_name=project,
+        profile=profile,
+        region_name=region_name,
+        enable_reaper=enable_session_timeout,
+        reaper_interval=session_timeout_interval,
+    )
     destroy_manifest = du.generate_deployed_manifest(deployment_name=deployment_name, skip_deploy_spec=False)
     if destroy_manifest:
         destroy_manifest.validate_and_set_module_defaults()

--- a/seedfarmer/commands/_module_commands.py
+++ b/seedfarmer/commands/_module_commands.py
@@ -239,7 +239,9 @@ def _execute_module_commands(
     session: Optional[Session] = None
 
     if not codeseeder.EXECUTING_REMOTELY:
-        session = SessionManager().get_or_create().get_deployment_session(account_id=account_id, region_name=region)
+        def session_getter() -> Session:
+            return SessionManager().get_or_create().get_deployment_session(account_id=account_id, region_name=region)
+        session = session_getter()
 
     @codeseeder.remote_function(
         config.PROJECT.lower(),
@@ -257,7 +259,7 @@ def _execute_module_commands(
         bundle_id=module_manifest_name,
         codebuild_compute_type=codebuild_compute_type,
         extra_files={config.CONFIG_FILE: os.path.join(config.OPS_ROOT, config.CONFIG_FILE)},
-        boto3_session=session,
+        boto3_session=session_getter,
     )
     def _execute_module_commands(
         deployment_name: str,

--- a/seedfarmer/commands/_module_commands.py
+++ b/seedfarmer/commands/_module_commands.py
@@ -239,8 +239,10 @@ def _execute_module_commands(
     session: Optional[Session] = None
 
     if not codeseeder.EXECUTING_REMOTELY:
+
         def session_getter() -> Session:
             return SessionManager().get_or_create().get_deployment_session(account_id=account_id, region_name=region)
+
         session = session_getter()
 
     @codeseeder.remote_function(

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     keywords=["aws", "cdk"],
     python_requires=">=3.7",
     install_requires=[
-        "aws-codeseeder~=0.5.2",
+        "aws-codeseeder~=0.6.0",
         "cookiecutter~=2.1.0",
         "pyhumps~=3.5.0",
         "pydantic~=1.9.0",


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*
- new --enable-session-timeout and --session-timeout-interval CLI params on apply and destroy.
   these parameters enable the boto3 Sessions to be refreshed during long deployments


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
