### PR TITLE
modified when deployspec is added to manifest object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ### Changes
 
 ### Fixes
+- removed the serialized deployspec from the module manifest ssm to prevent bloat (Issue #186)
 
 ## v2.3.0 (2022-11-09)
 

--- a/seedfarmer/commands/_deployment_commands.py
+++ b/seedfarmer/commands/_deployment_commands.py
@@ -446,7 +446,7 @@ def deploy_deployment(
 
             deployspec_path = get_deployspec_path(module_path)
             with open(deployspec_path) as module_spec_file:
-                module.deploy_spec = DeploySpec(**yaml.safe_load(module_spec_file))
+                deployspec = DeploySpec(**yaml.safe_load(module_spec_file))
 
             # This MD5 is generated from the module manifest content before setting the generated values
             # of `bundle_md5` and `deploy_spec` below
@@ -459,7 +459,7 @@ def deploy_deployment(
                 deployment_name=deployment_name,
                 group_name=group_name,
                 module_manifest=module,
-                module_deployspec=module.deploy_spec,
+                module_deployspec=deployspec,
                 module_deployspec_md5=module_deployspec_md5,
                 module_manifest_md5=module_manifest_md5,
                 dryrun=dryrun,
@@ -476,6 +476,7 @@ def deploy_deployment(
                 )
             else:
                 module.path = module_path
+                module.deploy_spec = deployspec
                 modules_to_deploy.append(module)
 
         if modules_to_deploy:


### PR DESCRIPTION
*Issue #, if available:*
#186 

*Description of changes:*
Changed when the deployspec is added to manifest object to prevent unnecessary data written to manifest ssm

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
