### PR TITLE
fix for dependabot 4 issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ### Changes
 
 ### Fixes
+- updated pip library to `certifi~=2022.12.7` in requirements-dev (ref dependabot #4)
 
 ## v2.3.1 (2022-11-22)
 

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,5 +1,6 @@
 awscli~=1.25.7
 black~=22.3.0
+certifi~=2022.12.7
 cfn-lint~=0.61.0
 check-manifest~=0.48
 flake8~=4.0.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -35,8 +35,10 @@ build==0.8.0
     # via
     #   check-manifest
     #   pyroma
-certifi==2022.5.18.1
-    # via requests
+certifi==2022.12.7
+    # via
+    #   -r requirements-dev.in
+    #   requests
 cfn-lint==0.61.0
     # via -r requirements-dev.in
 charset-normalizer==2.0.12


### PR DESCRIPTION
*Issue #, if available:*
[Dependabot 4](https://github.com/awslabs/seed-farmer/security/dependabot/4)

*Description of changes:*
Chang version of python library to `certifi~=2022.12.7`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
