### PR TITLE
catch exception when deleting project policy stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 - Added intra-group validation of parameter references (prevent any intra-group dependencies)
 
 ### Changes
+- catch exceptions when deleteing a deployment but the project policy (stack) is still in use elewhere
 
 ### Fixes
 - updated pip library to `certifi~=2022.12.7` in requirements-dev (ref dependabot #4)

--- a/seedfarmer/commands/_stack_commands.py
+++ b/seedfarmer/commands/_stack_commands.py
@@ -109,10 +109,17 @@ def destroy_managed_policy_stack(account_id: str, region: str) -> None:
         _logger.info(
             "Destroying Stack %s in Account/Region: %s/%s", info.PROJECT_MANAGED_POLICY_CFN_NAME, account_id, region
         )
-        services.cfn.destroy_stack(
-            stack_name=info.PROJECT_MANAGED_POLICY_CFN_NAME,
-            session=session,
-        )
+        import botocore.exceptions
+
+        try:
+            services.cfn.destroy_stack(
+                stack_name=info.PROJECT_MANAGED_POLICY_CFN_NAME,
+                session=session,
+            )
+        except (botocore.exceptions.WaiterError, botocore.exceptions.ClientError):
+            _logger.info(
+                f"Failed to delete project stack {info.PROJECT_MANAGED_POLICY_CFN_NAME}, ignoring and moving on"
+            )
 
 
 def destroy_module_stack(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When a project policy from a CFN stack is still in use (attached to a role, used in a different deployment) fails to delete when issuing a `seedfarmer destroy <project>` command due to conflict, catch the error as this is acceptable.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
