### PR TITLE
respect group ordering when deleting modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 - Added intra-group validation of parameter references (prevent any intra-group dependencies)
 
 ### Changes
-- catch exceptions when deleteing a deployment but the project policy (stack) is still in use elewhere
+- catch exceptions when deleting a deployment but the project policy (stack) is still in use elewhere
+- respect group ordering when destroying modules in an existing deployment
 
 ### Fixes
 - updated pip library to `certifi~=2022.12.7` in requirements-dev (ref dependabot #4)

--- a/seedfarmer/mgmt/deploy_utils.py
+++ b/seedfarmer/mgmt/deploy_utils.py
@@ -407,7 +407,7 @@ def filter_deploy_destroy(apply_manifest: DeploymentManifest, module_info_index:
     try:
         ordering = get_deployed_group_ordering(deployment_name)
 
-        def groupOrderingFilter(module: ModulesManifest):
+        def groupOrderingFilter(module: ModulesManifest) -> int:
             return ordering.get(module.name, 99)
 
         destroy_manifest.groups.sort(key=groupOrderingFilter)


### PR DESCRIPTION
*Issue #, if available:*
#202 

*Description of changes:*
When applying changes to a deployment that deletes modules, store the `destroy_manifest` groups in the same ordering as deployed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
