### PR TITLE
augment bundle path with module info for console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 - catch exceptions when deleting a deployment but the project policy (stack) is still in use elewhere
 - respect group ordering when destroying modules in an existing deployment
 - in `module_info` changed alias of import from `store` to `ssm`
+- include module reference info to `Source version` of Codebuild console
 
 ### Fixes
 - updated pip library to `certifi~=2022.12.7` in requirements-dev (ref dependabot #4)

--- a/seedfarmer/commands/_module_commands.py
+++ b/seedfarmer/commands/_module_commands.py
@@ -260,7 +260,7 @@ def _execute_module_commands(
             f"{config.PROJECT.lower()}-{deployment_name}-{group_name}"
             f"-{module_manifest_name}-{generate_session_hash(session=session)}"
         ),
-        bundle_id=module_manifest_name,
+        bundle_id=f"{deployment_name}-{group_name}-{module_manifest_name}",
         codebuild_compute_type=codebuild_compute_type,
         extra_files={config.CONFIG_FILE: os.path.join(config.OPS_ROOT, config.CONFIG_FILE)},
         boto3_session=session_getter,


### PR DESCRIPTION
*Issue #, if available:*
#56 

*Description of changes:*
Adding deployment-group-module to path of bundle in s3 for ease of lookup.

NOTE: the `setup.py` will need to reference the proper version of codeseeder ( > 0.6.0) for this to be realized.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
