### PR TITLE
adding vpc support for seedkit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,14 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ## Unreleased
 
 ### New
+- added VPC support of isolated subnets for `seedkit` - flow thru to codeseeder
 
 ### Changes
 
 ### Fixes
 - added module metadata to environment parameters on destroy of module
 - forced the `apply` of a deployment to respect the `toolchainRegion` parameter
+- allow fetch of build info of modules not successfully deployed
 
 
 ## v2.4.1 (2023-01-17)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -202,7 +202,7 @@ pyyaml==5.4.1
     #   sphinx-autoapi
 readme-renderer==35.0
     # via twine
-requests==2.28.0
+requests~=2.28.0
     # via
     #   pyroma
     #   requests-toolbelt

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 arrow==1.2.2
     # via jinja2-time
-aws-codeseeder==0.7.0
+aws-codeseeder==0.8.0
     # via seed-farmer (setup.py)
 binaryornot==0.4.4
     # via cookiecutter

--- a/seedfarmer/cli_groups/_list_group.py
+++ b/seedfarmer/cli_groups/_list_group.py
@@ -529,7 +529,9 @@ def list_build_env_params(
     load_dotenv(dotenv_path=os.path.join(config.OPS_ROOT, env_file), verbose=True, override=True)
 
     session = SessionManager().get_or_create(project_name=project, profile=profile, region_name=region)
-    dep_manifest = du.generate_deployed_manifest(deployment_name=deployment, skip_deploy_spec=True)
+    dep_manifest = du.generate_deployed_manifest(
+        deployment_name=deployment, skip_deploy_spec=True, ignore_deployed=True
+    )
 
     if dep_manifest is None:
         print(f"No module data found for {deployment}-{group}-{module}")

--- a/seedfarmer/commands/_deployment_commands.py
+++ b/seedfarmer/commands/_deployment_commands.py
@@ -318,7 +318,7 @@ def prime_target_accounts(deployment_manifest: DeploymentManifest) -> None:
             if target_account_region["network"]:
                 network = target_account_region["network"]
                 param_d["vpc_id"] = network.vpc_id  # type: ignore
-                param_d["subnet_ids"] = network.subnet_ids  # type: ignore
+                param_d["private_subnet_ids"] = network.private_subnet_ids  # type: ignore
                 param_d["security_group_ids"] = network.security_group_ids  # type: ignore
 
             params.append(param_d)

--- a/seedfarmer/commands/_stack_commands.py
+++ b/seedfarmer/commands/_stack_commands.py
@@ -344,7 +344,7 @@ def deploy_seedkit(
     account_id: str,
     region: str,
     vpc_id: Optional[str] = None,
-    subnet_ids: Optional[List[str]] = None,
+    private_subnet_ids: Optional[List[str]] = None,
     security_group_ids: Optional[List[str]] = None,
 ) -> None:
     """
@@ -359,10 +359,10 @@ def deploy_seedkit(
         The region where seedkit is deployed
     vpc_id: Optional[str]
         The VPC to associate seedkit with (codebuild)
-    subnet_ids: Optional[List[str]]
+    private_subnet_ids: Optional[List[str]]
         The Subnet IDs to associate seedkit with (codebuild)
     security_group_ids: Optional[List[str]]
-        The Securit Group IDs to associate seedkit with (codebuild)
+        The Security Group IDs to associate seedkit with (codebuild)
     """
     session = SessionManager().get_or_create().get_deployment_session(account_id=account_id, region_name=region)
     stack_exists, _, stack_outputs = commands.seedkit_deployed(seedkit_name=config.PROJECT, session=session)
@@ -376,7 +376,7 @@ def deploy_seedkit(
         deploy_codeartifact=deploy_codeartifact,
         session=session,
         vpc_id=vpc_id,
-        subnet_ids=subnet_ids,
+        subnet_ids=private_subnet_ids,
         security_group_ids=security_group_ids,
     )
 

--- a/seedfarmer/commands/_stack_commands.py
+++ b/seedfarmer/commands/_stack_commands.py
@@ -46,7 +46,9 @@ class StackInfo(object):
 info = StackInfo()
 
 
-def deploy_managed_policy_stack(deployment_manifest: DeploymentManifest, account_id: str, region: str) -> None:
+def deploy_managed_policy_stack(
+    deployment_manifest: DeploymentManifest, account_id: str, region: str, **kwargs
+) -> None:
     """
     deploy_managed_policy_stack
         This function deploys the deployment-specific policy to allow CodeSeeder to deploy.
@@ -58,7 +60,7 @@ def deploy_managed_policy_stack(deployment_manifest: DeploymentManifest, account
     account_id: str
         The Account Id where the module is deployed
     region: str
-        The region wher
+        The region
     """
     # Determine if managed policy stack already deployed
     session = SessionManager().get_or_create().get_deployment_session(account_id=account_id, region_name=region)
@@ -338,7 +340,13 @@ def deploy_module_stack(
         )
 
 
-def deploy_seedkit(account_id: str, region: str) -> None:
+def deploy_seedkit(
+    account_id: str,
+    region: str,
+    vpc_id: Optional[str] = None,
+    subnet_ids: Optional[List[str]] = None,
+    security_group_ids: Optional[List[str]] = None,
+) -> None:
     """
     deploy_seedkit
         Accessor method to CodeSeeder to deploy the SeedKit if not deployed
@@ -346,9 +354,16 @@ def deploy_seedkit(account_id: str, region: str) -> None:
     Parameters
     ----------
     account_id: str
-        The Account Id where the module is deployed
+        The Account Id where the seedkit is deployed
     region: str
-        The region wher"""
+        The region where seedkit is deployed
+    vpc_id: Optional[str]
+        The VPC to associate seedkit with (codebuild)
+    subnet_ids: Optional[List[str]]
+        The Subnet IDs to associate seedkit with (codebuild)
+    security_group_ids: Optional[List[str]]
+        The Securit Group IDs to associate seedkit with (codebuild)
+    """
     session = SessionManager().get_or_create().get_deployment_session(account_id=account_id, region_name=region)
     stack_exists, _, stack_outputs = commands.seedkit_deployed(seedkit_name=config.PROJECT, session=session)
     deploy_codeartifact = "CodeArtifactRepository" in stack_outputs
@@ -356,7 +371,14 @@ def deploy_seedkit(account_id: str, region: str) -> None:
         _logger.debug("Updating SeedKit for Account/Region: %s/%s", account_id, region)
     else:
         _logger.debug("Initializing SeedKit for Account/Region: %s/%s", account_id, region)
-    commands.deploy_seedkit(seedkit_name=config.PROJECT, deploy_codeartifact=deploy_codeartifact, session=session)
+    commands.deploy_seedkit(
+        seedkit_name=config.PROJECT,
+        deploy_codeartifact=deploy_codeartifact,
+        session=session,
+        vpc_id=vpc_id,
+        subnet_ids=subnet_ids,
+        security_group_ids=security_group_ids,
+    )
 
 
 def destroy_seedkit(account_id: str, region: str) -> None:

--- a/seedfarmer/commands/_stack_commands.py
+++ b/seedfarmer/commands/_stack_commands.py
@@ -16,7 +16,7 @@ import json
 import logging
 import os
 import time
-from typing import List, Optional, cast
+from typing import Any, List, Optional, cast
 
 from aws_codeseeder import EnvVar, codeseeder, commands, services
 from cfn_tools import load_yaml
@@ -47,7 +47,7 @@ info = StackInfo()
 
 
 def deploy_managed_policy_stack(
-    deployment_manifest: DeploymentManifest, account_id: str, region: str, **kwargs
+    deployment_manifest: DeploymentManifest, account_id: str, region: str, **kwargs: Any
 ) -> None:
     """
     deploy_managed_policy_stack

--- a/seedfarmer/mgmt/deploy_utils.py
+++ b/seedfarmer/mgmt/deploy_utils.py
@@ -323,6 +323,7 @@ def write_deployed_deployment_manifest(deployment_manifest: DeploymentManifest) 
 def generate_deployed_manifest(
     deployment_name: str,
     skip_deploy_spec: bool = False,
+    ignore_deployed: Optional[bool] = False,
 ) -> Optional[DeploymentManifest]:
     """
     Generate a DeploymentManifest object from based off deployed modules in a deployment
@@ -333,6 +334,9 @@ def generate_deployed_manifest(
         The name of the deployment the manifest is generated for
     skip_deploy_spec : bool, optional
         Skip populating each module deployspec - handy for getting the list of deployed modules quickly
+    ignore_deployed : Optional[bool]
+        When fetching the deployment manifest stored, ignore the successfully deployed modules,
+        forcing a fetch of the last requested deployment (to include modules that failed to deploy)
 
     Returns
     -------
@@ -341,7 +345,7 @@ def generate_deployed_manifest(
     """
     session_manager = SessionManager().get_or_create()
     dep_manifest_dict = mi.get_deployed_deployment_manifest(deployment_name, session=session_manager.toolchain_session)
-    if dep_manifest_dict is None:
+    if dep_manifest_dict is None or ignore_deployed:
         # No successful deployments, just use what was last requested
         dep_manifest_dict = mi.get_deployment_manifest(deployment_name, session=session_manager.toolchain_session)
     deployed_manifest = None

--- a/seedfarmer/models/manifests.py
+++ b/seedfarmer/models/manifests.py
@@ -162,7 +162,7 @@ class NetworkMapping(CamelModel):
     """
 
     vpc_id: Union[str, ValueFromRef]
-    subnet_ids: Union[List[str], ValueFromRef]
+    private_subnet_ids: Union[List[str], ValueFromRef]
     security_group_ids: Union[List[str], ValueFromRef]
 
     def __init__(self, **kwargs: Any) -> None:
@@ -190,11 +190,11 @@ class RegionMapping(CamelModel):
                     str,
                     self.parameters_regional.get(str(self.network.vpc_id.value_from.parameter_value)),  # type: ignore
                 )
-            if isinstance(self.network.subnet_ids, ValueFromRef):
-                self.network.subnet_ids = cast(
+            if isinstance(self.network.private_subnet_ids, ValueFromRef):
+                self.network.private_subnet_ids = cast(
                     List[str],
                     self.parameters_regional.get(
-                        str(self.network.subnet_ids.value_from.parameter_value)  # type: ignore
+                        str(self.network.private_subnet_ids.value_from.parameter_value)  # type: ignore
                     ),
                 )
             if isinstance(self.network.security_group_ids, ValueFromRef):

--- a/seedfarmer/models/manifests.py
+++ b/seedfarmer/models/manifests.py
@@ -378,7 +378,7 @@ class DeploymentManifest(CamelModel):
         account_id: Optional[str] = None,
         region: Optional[str] = None,
         default: Optional[str] = None,
-    ) -> Optional[str]:
+    ) -> Optional[Any]:
         if account_alias is not None and account_id is not None:
             raise ValueError("Only one of 'account_alias' and 'account_id' is allowed")
 

--- a/setup.py
+++ b/setup.py
@@ -45,14 +45,14 @@ setup(
     keywords=["aws", "cdk"],
     python_requires=">=3.7",
     install_requires=[
-        "aws-codeseeder~=0.7.0",
+        "aws-codeseeder~=0.8.0",
         "cookiecutter~=2.1.0",
         "pyhumps~=3.5.0",
         "pydantic~=1.9.0",
         "executor~=23.2",
         "typing-extensions~=4.2.0",
         "rich~=12.4.0",
-        "requests==2.28.1",
+        "requests~=2.28.0",
         "python-dotenv~=0.21.0",
         "gitpython~=3.1.27",
         "gitignore-parser~=0.1.2"


### PR DESCRIPTION
*Issue #, if available:*
#228 
#226 
#227 

*Description of changes:*

- Allow `seedfarmer` to pass VPC info to the creation of the seedkit
- add CLI support for seedkit with VPC
- enable fetch of modules build parameters when a module has not deployed successfully

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
