### PR TITLE
force use of codebuild role name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 
 ### Fixes
 - Adding more descriptions in the README with links to read-the-docs
+- Fix codebuild role name reference
+- Fix support for project names with `-` characters
 
 
 ## v2.5.0 (2023-02-08)

--- a/examples/exampleproject/modules/optionals/buckets/app.py
+++ b/examples/exampleproject/modules/optionals/buckets/app.py
@@ -8,7 +8,7 @@ project_name = os.getenv("AWS_CODESEEDER_NAME")
 
 
 def _proj(name: str) -> str:
-    return f"{project_name.upper()}_{name}"
+    return f"{project_name.upper()}_{name}".replace("-","_")
 
 
 def _param(name: str) -> str:

--- a/examples/exampleproject/modules/optionals/buckets/deployspec.yaml
+++ b/examples/exampleproject/modules/optionals/buckets/deployspec.yaml
@@ -9,10 +9,8 @@ deploy:
       commands:
       # execute the CDK
       - cdk deploy --require-approval never --progress events --app "python app.py" --outputs-file ./cdk-exports.json
-      # derive the metadata environment parameter name that seedfarmer is looking for from the CODESEEDER project name
-      - export P_METADATA=$(echo $AWS_CODESEEDER_NAME | tr '[:lower:]' '[:upper:]')_MODULE_METADATA
-      # assign that paramter name the output from CDK by calling a custom python script
-      - export ${P_METADATA}=$(python export_metadata.py)
+      # get the cdk.output and write to a file named <project>_MODULE_METADATA --- ALL UPPERCASE AND '_'
+      - python export_metadata.py
 destroy:
   phases:
     install:

--- a/examples/exampleproject/modules/optionals/buckets/export_metadata.py
+++ b/examples/exampleproject/modules/optionals/buckets/export_metadata.py
@@ -2,7 +2,12 @@ import json
 import os
 
 p = os.getenv("AWS_CODESEEDER_NAME")
-d = os.getenv(f"{p.upper()}_DEPLOYMENT_NAME")
-m = os.getenv(f"{p.upper()}_MODULE_NAME")
-file = open("cdk-exports.json")
-print(json.load(file)[f"{p}-{d}-{m}"]["metadata"])
+p_fetch = p.replace("-","_").upper()
+
+d = os.getenv(f"{p_fetch}_DEPLOYMENT_NAME")
+m = os.getenv(f"{p_fetch}_MODULE_NAME")
+cdk_output = open("cdk-exports.json")
+data = json.load(cdk_output)[f"{p}-{d}-{m}"]["metadata"]
+
+with open(f"{p_fetch}_MODULE_METADATA", 'w') as f:
+    f.write(data)

--- a/examples/exampleproject/modules/optionals/networking/app.py
+++ b/examples/exampleproject/modules/optionals/networking/app.py
@@ -8,7 +8,7 @@ project_name = os.getenv("AWS_CODESEEDER_NAME")
 
 
 def _proj(name: str) -> str:
-    return f"{project_name.upper()}_{name}"
+    return f"{project_name.upper()}_{name}".replace("-","_")
 
 
 def _param(name: str) -> str:

--- a/examples/exampleproject/modules/optionals/networking/deployspec.yaml
+++ b/examples/exampleproject/modules/optionals/networking/deployspec.yaml
@@ -9,10 +9,8 @@ deploy:
       commands:
       # execute the CDK
       - cdk deploy --require-approval never --progress events --app "python app.py" --outputs-file ./cdk-exports.json
-      # derive the metadata environment parameter name that seedfarmer is looking for from the CODESEEDER project name
-      - export P_METADATA=$(echo $AWS_CODESEEDER_NAME | tr '[:lower:]' '[:upper:]')_MODULE_METADATA
-      # assign that paramter name the output from CDK by calling a custom python script
-      - export ${P_METADATA}=$(python export_metadata.py)
+      # get the cdk.output and write to a file named <project>_MODULE_METADATA --- ALL UPPERCASE AND '_'
+      - python export_metadata.py
 destroy:
   phases:
     install:

--- a/examples/exampleproject/modules/optionals/networking/export_metadata.py
+++ b/examples/exampleproject/modules/optionals/networking/export_metadata.py
@@ -2,7 +2,12 @@ import json
 import os
 
 p = os.getenv("AWS_CODESEEDER_NAME")
-d = os.getenv(f"{p.upper()}_DEPLOYMENT_NAME")
-m = os.getenv(f"{p.upper()}_MODULE_NAME")
-file = open("cdk-exports.json")
-print(json.load(file)[f"{p}-{d}-{m}"]["metadata"])
+p_fetch = p.replace("-","_").upper()
+
+d = os.getenv(f"{p_fetch}_DEPLOYMENT_NAME")
+m = os.getenv(f"{p_fetch}_MODULE_NAME")
+cdk_output = open("cdk-exports.json")
+data = json.load(cdk_output)[f"{p}-{d}-{m}"]["metadata"]
+
+with open(f"{p_fetch}_MODULE_METADATA", 'w') as f:
+    f.write(data)

--- a/seedfarmer/commands/__init__.py
+++ b/seedfarmer/commands/__init__.py
@@ -23,6 +23,7 @@ from seedfarmer.commands._stack_commands import (
     destroy_managed_policy_stack,
     destroy_module_stack,
     destroy_seedkit,
+    get_module_stack_info,
 )
 
 __all__ = [
@@ -36,6 +37,7 @@ __all__ = [
     "destroy_module_stack",
     "deploy_seedkit",
     "destroy_seedkit",
+    "get_module_stack_info",
     "generate_export_env_params",
     "generate_export_raw_env_params",
     "bootstrap_toolchain_account",

--- a/seedfarmer/commands/_module_commands.py
+++ b/seedfarmer/commands/_module_commands.py
@@ -26,7 +26,7 @@ from boto3 import Session
 
 from seedfarmer import config
 from seedfarmer.models.deploy_responses import CodeSeederMetadata, ModuleDeploymentResponse, StatusType
-from seedfarmer.models.manifests import DeploySpec, ModuleParameter
+from seedfarmer.models.manifests import ModuleManifest, ModuleParameter
 from seedfarmer.services.session_manager import SessionManager
 from seedfarmer.utils import generate_session_hash
 
@@ -34,7 +34,8 @@ _logger: logging.Logger = logging.getLogger(__name__)
 
 
 def _param(key: str) -> str:
-    return f"{config.PROJECT.upper()}_{key}"
+    p = config.PROJECT.upper().replace("-", "_")
+    return f"{p}_{key}"
 
 
 def _env_vars(
@@ -72,33 +73,31 @@ def _env_vars(
 def deploy_module(
     deployment_name: str,
     group_name: str,
-    module_path: str,
-    module_deploy_spec: DeploySpec,
-    module_manifest_name: str,
+    module_manifest: ModuleManifest,
     account_id: str,
     region: str,
     parameters: Optional[List[ModuleParameter]] = None,
     module_metadata: Optional[str] = None,
-    module_bundle_md5: Optional[str] = None,
     docker_credentials_secret: Optional[str] = None,
     permissions_boundary_arn: Optional[str] = None,
+    module_role_name: Optional[str] = None,
 ) -> ModuleDeploymentResponse:
     env_vars = _env_vars(
         deployment_name=deployment_name,
         group_name=group_name,
-        module_manifest_name=module_manifest_name,
+        module_manifest_name=module_manifest.name,
         parameters=parameters,
         module_metadata=module_metadata,
         docker_credentials_secret=docker_credentials_secret,
         permissions_boundary_arn=permissions_boundary_arn,
         session=SessionManager().get_or_create().get_deployment_session(account_id=account_id, region_name=region),
     )
-    env_vars[_param("MODULE_MD5")] = module_bundle_md5 if module_bundle_md5 is not None else ""
+    env_vars[_param("MODULE_MD5")] = module_manifest.bundle_md5 if module_manifest.bundle_md5 is not None else ""
 
     md5_put = [
         (
-            f"echo {module_bundle_md5} | seedfarmer store md5 -d {deployment_name} "
-            f"-g {group_name} -m {module_manifest_name} -t bundle --debug ;"
+            f"echo {module_manifest.bundle_md5} | seedfarmer store md5 -d {deployment_name} "
+            f"-g {group_name} -m {module_manifest.name} -t bundle --debug ;"
         )
     ]
     pmd = _param("MODULE_METADATA")
@@ -106,19 +105,20 @@ def deploy_module(
         f"if [[ -f {pmd} ]]; then export {pmd}=$(cat {pmd}); fi",
         (
             f"echo ${pmd} | seedfarmer store moduledata "
-            f"-d {deployment_name} -g {group_name} -m {module_manifest_name}"
+            f"-d {deployment_name} -g {group_name} -m {module_manifest.name}"
         ),
     ]
 
-    if module_deploy_spec.deploy is None:
+    if module_manifest.deploy_spec is None or module_manifest.deploy_spec.deploy is None:
         raise ValueError("Missing `deploy` in module's deployspec.yaml")
 
-    _phases = module_deploy_spec.deploy.phases
+    module_path = os.path.join(config.OPS_ROOT, module_manifest.path)
+    _phases = module_manifest.deploy_spec.deploy.phases
     try:
         resp_dict_str, dict_metadata = _execute_module_commands(
             deployment_name=deployment_name,
             group_name=group_name,
-            module_manifest_name=module_manifest_name,
+            module_manifest_name=module_manifest.name,
             account_id=account_id,
             region=region,
             extra_dirs={"module": module_path},
@@ -127,14 +127,15 @@ def deploy_module(
             extra_build_commands=["cd module/"] + _phases.build.commands,
             extra_post_build_commands=["cd module/"] + _phases.post_build.commands + md5_put + metadata_put,
             extra_env_vars=env_vars,
-            codebuild_compute_type=module_deploy_spec.build_type,
+            codebuild_compute_type=module_manifest.deploy_spec.build_type,
+            codebuild_role_name=module_role_name,
         )
         _logger.debug("CodeSeeder Metadata response is %s", dict_metadata)
 
         resp = ModuleDeploymentResponse(
             deployment=deployment_name,
             group=group_name,
-            module=module_manifest_name,
+            module=module_manifest.name,
             status=StatusType.SUCCESS.value,
             codeseeder_metadata=CodeSeederMetadata(**json.loads(resp_dict_str)) if resp_dict_str else None,
             codeseeder_output=dict_metadata,
@@ -145,7 +146,7 @@ def deploy_module(
         resp = ModuleDeploymentResponse(
             deployment=deployment_name,
             group=group_name,
-            module=module_manifest_name,
+            module=module_manifest.name,
             status=StatusType.ERROR.value,
             codeseeder_metadata=CodeSeederMetadata(**l_case_error),
         )
@@ -156,42 +157,40 @@ def destroy_module(
     deployment_name: str,
     group_name: str,
     module_path: str,
-    module_deploy_spec: DeploySpec,
-    module_manifest_name: str,
+    module_manifest: ModuleManifest,
     account_id: str,
     region: str,
     parameters: Optional[List[ModuleParameter]] = None,
     module_metadata: Optional[str] = None,
+    module_role_name: Optional[str] = None,
 ) -> ModuleDeploymentResponse:
     env_vars = _env_vars(
         deployment_name=deployment_name,
         group_name=group_name,
-        module_manifest_name=module_manifest_name,
+        module_manifest_name=module_manifest.name,
         parameters=parameters,
         module_metadata=module_metadata,
         session=SessionManager().get_or_create().get_deployment_session(account_id=account_id, region_name=region),
     )
 
-    remove_ssm = [f"seedfarmer remove moduledata -d {deployment_name} -g {group_name} -m {module_manifest_name}"]
+    remove_ssm = [f"seedfarmer remove moduledata -d {deployment_name} -g {group_name} -m {module_manifest.name}"]
 
     export_info = [
         f"export DEPLOYMENT={deployment_name}",
         f"export GROUP={group_name}",
-        f"export MODULE={module_manifest_name}",
+        f"export MODULE={module_manifest.name}",
     ]
 
-    if module_deploy_spec.destroy is None:
-        raise ValueError(
-            f"Missing `destroy` in module: {module_manifest_name} with {module_deploy_spec.destroy} deployspec.yaml"
-        )
+    if module_manifest.deploy_spec is None or module_manifest.deploy_spec.destroy is None:
+        raise ValueError(f"Missing `destroy` in module: {module_manifest.name} with deployspec.yaml")
 
-    _phases = module_deploy_spec.destroy.phases
+    _phases = module_manifest.deploy_spec.destroy.phases
 
     try:
         resp_dict_str, _ = _execute_module_commands(
             deployment_name=deployment_name,
             group_name=group_name,
-            module_manifest_name=module_manifest_name,
+            module_manifest_name=module_manifest.name,
             account_id=account_id,
             region=region,
             extra_dirs={"module": module_path},
@@ -200,12 +199,13 @@ def destroy_module(
             extra_build_commands=["cd module/"] + _phases.build.commands,
             extra_post_build_commands=["cd module/"] + _phases.post_build.commands + remove_ssm,
             extra_env_vars=env_vars,
-            codebuild_compute_type=module_deploy_spec.build_type,
+            codebuild_compute_type=module_manifest.deploy_spec.build_type,
+            codebuild_role_name=module_role_name,
         )
         resp = ModuleDeploymentResponse(
             deployment=deployment_name,
             group=group_name,
-            module=module_manifest_name,
+            module=module_manifest.name,
             status=StatusType.SUCCESS.value,
             codeseeder_metadata=CodeSeederMetadata(**json.loads(resp_dict_str)) if resp_dict_str else None,
         )
@@ -215,7 +215,7 @@ def destroy_module(
         resp = ModuleDeploymentResponse(
             deployment=deployment_name,
             group=group_name,
-            module=module_manifest_name,
+            module=module_manifest.name,
             status=StatusType.ERROR.value,
             codeseeder_metadata=CodeSeederMetadata(**l_case_error),
         )
@@ -235,8 +235,8 @@ def _execute_module_commands(
     extra_post_build_commands: Optional[List[str]] = None,
     extra_env_vars: Optional[Dict[str, Any]] = None,
     codebuild_compute_type: Optional[str] = None,
+    codebuild_role_name: Optional[str] = None,
 ) -> Tuple[str, Optional[Dict[str, str]]]:
-    session: Optional[Session] = None
     session_getter: Optional[Callable[[], Session]] = None
 
     if not codeseeder.EXECUTING_REMOTELY:
@@ -245,7 +245,6 @@ def _execute_module_commands(
             return SessionManager().get_or_create().get_deployment_session(account_id=account_id, region_name=region)
 
         session_getter = _session_getter
-        session = session_getter()
 
     @codeseeder.remote_function(
         config.PROJECT.lower(),
@@ -256,10 +255,7 @@ def _execute_module_commands(
         extra_post_build_commands=extra_post_build_commands,
         extra_env_vars=extra_env_vars,
         extra_exported_env_vars=[f"{_param('MODULE_METADATA')}"],
-        codebuild_role=(
-            f"{config.PROJECT.lower()}-{deployment_name}-{group_name}"
-            f"-{module_manifest_name}-{generate_session_hash(session=session)}"
-        ),
+        codebuild_role=codebuild_role_name,
         bundle_id=f"{deployment_name}-{group_name}-{module_manifest_name}",
         codebuild_compute_type=codebuild_compute_type,
         extra_files={config.CONFIG_FILE: os.path.join(config.OPS_ROOT, config.CONFIG_FILE)},

--- a/seedfarmer/commands/_stack_commands.py
+++ b/seedfarmer/commands/_stack_commands.py
@@ -16,7 +16,7 @@ import json
 import logging
 import os
 import time
-from typing import Any, List, Optional, cast
+from typing import Any, List, Optional, Tuple, cast
 
 from aws_codeseeder import EnvVar, codeseeder, commands, services
 from cfn_tools import load_yaml
@@ -200,7 +200,7 @@ def deploy_module_stack(
     parameters: List[ModuleParameter],
     docker_credentials_secret: Optional[str] = None,
     permissions_boundary_arn: Optional[str] = None,
-) -> None:
+) -> Tuple[str, str]:
     """
     deploy_module_stack
         This function deploys the module stack (modulestack.yaml) to support the module
@@ -338,6 +338,47 @@ def deploy_module_stack(
         iam.attach_inline_policy(
             role_name=module_role_name, policy_body=policy_body, policy_name=docker_credentials_secret, session=session
         )
+
+    return module_stack_name, module_role_name
+
+
+def get_module_stack_info(
+    deployment_name: str,
+    group_name: str,
+    module_name: str,
+    account_id: str,
+    region: str,
+) -> Tuple[str, str]:
+    """
+    get_module_stack_info
+        This function returns the name of the role and the name of the stack associated with the
+        module deployment role
+
+    Parameters
+    ----------
+    deployment_name : str
+        Deployment Name
+    group_name : str
+        Group name
+    module_name : str
+        Module Name
+    account_id : str
+        The account id where deployed
+    region : str
+        The region where deployed
+
+    Returns
+    -------
+    Tuple[str, str]
+        A tuple with the  module_stack_name and  module_role_name
+        [ module_stack_name, module_role_name ]
+    """
+
+    session = SessionManager().get_or_create().get_deployment_session(account_id=account_id, region_name=region)
+    module_stack_name, module_role_name = get_module_stack_names(
+        deployment_name, group_name, module_name, session=session
+    )
+    return module_stack_name, module_role_name
 
 
 def deploy_seedkit(


### PR DESCRIPTION
*Issue #, if available:*
#241 

*Description of changes:*

- Pass the codebuild role name thru the invocation once generated
- Make sample modules easier to understand metadata capture
- add support for project names with `-` 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
