### PR TITLE
adding support to change codebuild image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ## Unreleased
 
 ### New
-
+- Adding support for customer codebuild image overrides.  This IS backward-compatible
 ### Changes
 
 ### Fixes

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 arrow==1.2.2
     # via jinja2-time
-aws-codeseeder==0.8.0
+aws-codeseeder==0.8.1
     # via seed-farmer (setup.py)
 binaryornot==0.4.4
     # via cookiecutter

--- a/seedfarmer/commands/_deployment_commands.py
+++ b/seedfarmer/commands/_deployment_commands.py
@@ -105,6 +105,7 @@ def _execute_deploy(
     deployment_manifest: DeploymentManifest,
     docker_credentials_secret: Optional[str] = None,
     permissions_boundary_arn: Optional[str] = None,
+    codebuild_image: Optional[str] = None,
 ) -> ModuleDeploymentResponse:
 
     parameters = load_parameter_values(
@@ -162,6 +163,7 @@ def _execute_deploy(
         docker_credentials_secret=docker_credentials_secret,
         permissions_boundary_arn=permissions_boundary_arn,
         module_role_name=module_role_name,
+        codebuild_image=codebuild_image,
     )
 
 
@@ -171,6 +173,7 @@ def _execute_destroy(
     module_path: str,
     deployment_manifest: DeploymentManifest,
     docker_credentials_secret: Optional[str] = None,
+    codebuild_image: Optional[str] = None,
 ) -> Optional[ModuleDeploymentResponse]:
     if module_manifest.deploy_spec is None:
         raise ValueError(
@@ -210,6 +213,7 @@ def _execute_destroy(
         ),
         module_metadata=module_metadata,
         module_role_name=module_role_name,
+        codebuild_image=codebuild_image,
     )
 
     if resp.status == StatusType.SUCCESS.value:
@@ -275,6 +279,9 @@ def _deploy_deployment_is_not_dry_run(
                                     account_alias=_module.target_account,
                                     region=_module.target_region,
                                 ),
+                            ),
+                            "codebuild_image": deployment_manifest_wip.get_region_codebuild_image(
+                                account_alias=_module.target_account, region=_module.target_region
                             ),
                         }
                         for _module in _group.modules
@@ -409,6 +416,9 @@ def destroy_deployment(
                                 "dockerCredentialsSecret",
                                 account_alias=_module.target_account,
                                 region=_module.target_region,
+                            ),
+                            "codebuild_image": destroy_manifest.get_region_codebuild_image(
+                                account_alias=_module.target_account, region=_module.target_region
                             ),
                         }
                         for _module in _group.modules

--- a/seedfarmer/commands/_module_commands.py
+++ b/seedfarmer/commands/_module_commands.py
@@ -81,6 +81,7 @@ def deploy_module(
     docker_credentials_secret: Optional[str] = None,
     permissions_boundary_arn: Optional[str] = None,
     module_role_name: Optional[str] = None,
+    codebuild_image: Optional[str] = None,
 ) -> ModuleDeploymentResponse:
     env_vars = _env_vars(
         deployment_name=deployment_name,
@@ -129,6 +130,9 @@ def deploy_module(
             extra_env_vars=env_vars,
             codebuild_compute_type=module_manifest.deploy_spec.build_type,
             codebuild_role_name=module_role_name,
+            codebuild_image=module_manifest.codebuild_image
+            if module_manifest.codebuild_image is not None
+            else codebuild_image,
         )
         _logger.debug("CodeSeeder Metadata response is %s", dict_metadata)
 
@@ -163,6 +167,7 @@ def destroy_module(
     parameters: Optional[List[ModuleParameter]] = None,
     module_metadata: Optional[str] = None,
     module_role_name: Optional[str] = None,
+    codebuild_image: Optional[str] = None,
 ) -> ModuleDeploymentResponse:
     env_vars = _env_vars(
         deployment_name=deployment_name,
@@ -201,6 +206,9 @@ def destroy_module(
             extra_env_vars=env_vars,
             codebuild_compute_type=module_manifest.deploy_spec.build_type,
             codebuild_role_name=module_role_name,
+            codebuild_image=module_manifest.codebuild_image
+            if module_manifest.codebuild_image is not None
+            else codebuild_image,
         )
         resp = ModuleDeploymentResponse(
             deployment=deployment_name,
@@ -236,6 +244,7 @@ def _execute_module_commands(
     extra_env_vars: Optional[Dict[str, Any]] = None,
     codebuild_compute_type: Optional[str] = None,
     codebuild_role_name: Optional[str] = None,
+    codebuild_image: Optional[str] = None,
 ) -> Tuple[str, Optional[Dict[str, str]]]:
     session_getter: Optional[Callable[[], Session]] = None
 
@@ -256,6 +265,7 @@ def _execute_module_commands(
         extra_env_vars=extra_env_vars,
         extra_exported_env_vars=[f"{_param('MODULE_METADATA')}"],
         codebuild_role=codebuild_role_name,
+        codebuild_image=codebuild_image,
         bundle_id=f"{deployment_name}-{group_name}-{module_manifest_name}",
         codebuild_compute_type=codebuild_compute_type,
         extra_files={config.CONFIG_FILE: os.path.join(config.OPS_ROOT, config.CONFIG_FILE)},

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     keywords=["aws", "cdk"],
     python_requires=">=3.7",
     install_requires=[
-        "aws-codeseeder~=0.8.0",
+        "aws-codeseeder~=0.8.1",
         "cookiecutter~=2.1.0",
         "pyhumps~=3.5.0",
         "pydantic~=1.9.0",


### PR DESCRIPTION
*Issue #, if available:*
#242 

*Description of changes:*
Added new named parameter `codebuildImage` or `codebuild_image` to support using a custom codebuild image with seedfarmer / codeseeder.  NOTE: the image MUST use the aws-codeseeder image as the base.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
