### PR TITLE
Feature/Enable use of generic Env Variables in CodeBuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 
 ### New
 - Adding support for customer codebuild image overrides.  This IS backward-compatible
+- Enable use of generic SEEDFARMER prefixed Env Variables in CodeBuild
+- Example modules demonstrate use of SEEDFARMER generic Env Variables
+
 ### Changes
+- {ProjectName}_PROJECT_NAME and SEEDFARMER_PROJECT_NAME Env Variables added to CodeBuild
+- ProjectName Parameter passed to modulestack.yaml CFN Template
 
 ### Fixes
 - Adding more descriptions in the README with links to read-the-docs

--- a/examples/exampleproject/modules/optionals/buckets/app.py
+++ b/examples/exampleproject/modules/optionals/buckets/app.py
@@ -4,24 +4,14 @@ import aws_cdk
 from aws_cdk import App, CfnOutput
 from stack import BucketsStack
 
-project_name = os.getenv("AWS_CODESEEDER_NAME")
+project_name = os.getenv("SEEDFARMER_PROJECT_NAME", "")
+deployment_name = os.getenv("SEEDFARMER_DEPLOYMENT_NAME", "")
+module_name = os.getenv("SEEDFARMER_MODULE_NAME", "")
+hash = os.getenv("SEEDFARMER_HASH", "")
 
 
-def _proj(name: str) -> str:
-    return f"{project_name.upper()}_{name}".replace("-","_")
-
-
-def _param(name: str) -> str:
-    return f"{project_name.upper()}_PARAMETER_{name}"
-
-
-deployment_name = os.getenv(_proj("DEPLOYMENT_NAME"), "")
-module_name = os.getenv(_proj("MODULE_NAME"), "")
-hash = os.getenv(_proj("HASH"), "")
-
-
-buckets_encryption_type = os.getenv(_param("ENCRYPTION_TYPE"), "SSE")
-buckets_retention = os.getenv(_param("RETENTION_TYPE"), "DESTROY")
+buckets_encryption_type = os.getenv("SEEDFARMER_PARAMETER_ENCRYPTION_TYPE", "SSE")
+buckets_retention = os.getenv("SEEDFARMER_PARAMETER_RETENTION_TYPE", "DESTROY")
 
 
 app = App()

--- a/examples/exampleproject/modules/optionals/buckets/deployspec.yaml
+++ b/examples/exampleproject/modules/optionals/buckets/deployspec.yaml
@@ -1,8 +1,9 @@
+publishGenericEnvVariables: true
 deploy:
   phases:
     install:
       commands:
-      # Install whatever additional build libraries 
+      # Install whatever additional build libraries
       - npm install -g aws-cdk@2.20.0
       - pip install -r requirements.txt
     build:
@@ -15,12 +16,10 @@ destroy:
   phases:
     install:
       commands:
-      # Install whatever additional build libraries 
+      # Install whatever additional build libraries
       - npm install -g aws-cdk@2.20.0
       - pip install -r requirements.txt
     build:
       commands:
       # execute the CDK
       - cdk destroy --force --app "python app.py"
-
-

--- a/examples/exampleproject/modules/optionals/buckets/export_metadata.py
+++ b/examples/exampleproject/modules/optionals/buckets/export_metadata.py
@@ -1,13 +1,12 @@
 import json
 import os
 
-p = os.getenv("AWS_CODESEEDER_NAME")
-p_fetch = p.replace("-","_").upper()
+p = os.getenv("SEEDFARMER_PROJECT_NAME")
+d = os.getenv("SEEDFARMER_DEPLOYMENT_NAME")
+m = os.getenv("SEEDFARMER_MODULE_NAME")
 
-d = os.getenv(f"{p_fetch}_DEPLOYMENT_NAME")
-m = os.getenv(f"{p_fetch}_MODULE_NAME")
 cdk_output = open("cdk-exports.json")
 data = json.load(cdk_output)[f"{p}-{d}-{m}"]["metadata"]
 
-with open(f"{p_fetch}_MODULE_METADATA", 'w') as f:
+with open("SEEDFARMER_MODULE_METADATA", 'w') as f:
     f.write(data)

--- a/examples/exampleproject/modules/optionals/networking/app.py
+++ b/examples/exampleproject/modules/optionals/networking/app.py
@@ -4,22 +4,12 @@ import aws_cdk
 from aws_cdk import App, CfnOutput
 from stack import NetworkingStack
 
-project_name = os.getenv("AWS_CODESEEDER_NAME")
+project_name = os.getenv("SEEDFARMER_PROJECT_NAME", "")
+deployment_name = os.getenv("SEEDFARMER_DEPLOYMENT_NAME", "")
+module_name = os.getenv("SEEDFARMER_MODULE_NAME", "")
+hash = os.getenv("SEEDFARMER_HASH", "")
 
-
-def _proj(name: str) -> str:
-    return f"{project_name.upper()}_{name}".replace("-","_")
-
-
-def _param(name: str) -> str:
-    return f"{project_name.upper()}_PARAMETER_{name}"
-
-
-# get the env parameters with proper prefixes
-deployment_name = os.getenv(_proj("DEPLOYMENT_NAME"), "")
-module_name = os.getenv(_proj("MODULE_NAME"), "")
-hash = os.getenv(_proj("HASH"), "")
-internet_accessible = os.getenv(_param("INTERNET_ACCESSIBLE"), True)
+internet_accessible = os.getenv("SEEDFARMER_PARAMETER_INTERNET_ACCESSIBLE", "true").lower() == "true"
 
 app = App()
 

--- a/examples/exampleproject/modules/optionals/networking/deployspec.yaml
+++ b/examples/exampleproject/modules/optionals/networking/deployspec.yaml
@@ -1,3 +1,4 @@
+publishGenericEnvVariables: true
 deploy:
   phases:
     install:
@@ -22,5 +23,3 @@ destroy:
       commands:
       # execute the CDK
       - cdk destroy --force --app "python app.py"
-
-

--- a/examples/exampleproject/modules/optionals/networking/export_metadata.py
+++ b/examples/exampleproject/modules/optionals/networking/export_metadata.py
@@ -1,13 +1,12 @@
 import json
 import os
 
-p = os.getenv("AWS_CODESEEDER_NAME")
-p_fetch = p.replace("-","_").upper()
+p = os.getenv("SEEDFARMER_PROJECT_NAME")
+d = os.getenv("SEEDFARMER_DEPLOYMENT_NAME")
+m = os.getenv("SEEDFARMER_MODULE_NAME")
 
-d = os.getenv(f"{p_fetch}_DEPLOYMENT_NAME")
-m = os.getenv(f"{p_fetch}_MODULE_NAME")
 cdk_output = open("cdk-exports.json")
 data = json.load(cdk_output)[f"{p}-{d}-{m}"]["metadata"]
 
-with open(f"{p_fetch}_MODULE_METADATA", 'w') as f:
+with open("SEEDFARMER_MODULE_METADATA", 'w') as f:
     f.write(data)

--- a/examples/exampleproject/modules/optionals/networking/stack.py
+++ b/examples/exampleproject/modules/optionals/networking/stack.py
@@ -22,7 +22,6 @@ from constructs import Construct, IConstruct
 
 _logger: logging.Logger = logging.getLogger(__name__)
 
-
 class NetworkingStack(Stack):  # type: ignore
     def __init__(
         self,

--- a/seedfarmer/commands/_stack_commands.py
+++ b/seedfarmer/commands/_stack_commands.py
@@ -256,6 +256,7 @@ def deploy_module_stack(
         upper_snake_case_parameters = {
             **{p.upper_snake_case: p.value for p in parameters},
             **{
+                "PROJECT_NAME": config.PROJECT,
                 "DEPLOYMENT_NAME": deployment_name,
                 "MODULE_NAME": group_module_name,
                 "ROLE_NAME": module_role_name,

--- a/seedfarmer/models/manifests.py
+++ b/seedfarmer/models/manifests.py
@@ -73,6 +73,7 @@ class DeploySpec(CamelModel):
     deploy: Optional[ExecutionType] = None
     destroy: Optional[ExecutionType] = None
     build_type: Optional[str] = None
+    publish_generic_env_variables: Optional[bool] = False
 
     def __init__(self, **data: Any) -> None:
         super().__init__(**data)


### PR DESCRIPTION
**ssue #, if available:** None

**Description of changes:**
- enables module builders to use generic Env Variables, rather than Project specific, within CodeBuild
- updates the example `networking` and `buckets` modules to demonstrate usage of these generic variables
- adds `{ProjectName}_PROJECT_NAME` and `SEEDFARMER_PROJECT_NAME` Env Variables to CodeBuild
- adds `ProjectName` Parameter to `modulestack.yaml` CFN Templates

**Usage details**
When creating a module, builders can now specify the optional `publishGenericEnvVariables` attribute in the module `deployspec.yaml`. When set to `true` the Env Variables passed to CodeBuild for SeedFarmer metadata (ProjectName, DeploymentName, ModuleName, etc) are prefixed with `SEEDFARMER_` rather than the UPPER ProjectName. From the included `exampleproj` project in examples: `EXAMPLEPROJ_DEPLOYMENT_NAME` would be `SEEDFARMER_DEPLOYMENT_NAME`. And for Module Parameters, `EXAMPLEPROJ_PARAMETER_SOME_PARAMETER` would be `SEEDFARMER_PARAMETER_SOME_PARAMETER`. 

_See `examples/exampleproj/modules/networking/` and `examples/exampleproj/modules/buckets/` for demonstration_

**Design**
This design was chosen as it puts the decision to use, and work to implement, strictly on the module builder. Module builders can decide to create generic, reusable or project specific modules. Module consumers can use generic modules transparently without any updates to code or manifests. Module consumers working within the same project can also consume Project specific modules transparently and without update. Should a Module consumer decide to use a non-generic module from another project, this design forces them to inspect and update the module (a best practice).

This PR continues to prefix all Env Variables created by SeedFarmer and passed to CodeBuild with a deterministic prefix, enabling identification, avoiding collisions, and following the pattern established by the CodeBuild service (documented here: https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html). Usage of a generic prefix enables modules to be used in multiple projects without requiring dynamic Env Variable name determination or grep/replace of ProjectName in module source. 

_Note: best practice still requires use of ProjectName for Resource scoping within IAM and Resource Policies_

The `publishGenericEnvVariables` attribute was made optional and defaulted to `false` in order to maintain full, non-breaking backwards compatibility with existing modules and deployments. Over time, it may be shown that usage of the generic Env Variables may be an easier and better solution than the Project specific ones.

**Alternatives considered**
Enabling a Consumer specified Project through the module manifest was considered, as was duplicating all Env Variables with both `{ProjectName}_` and `SEEDFARMER_` for backwards compatibility. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
