### PR TITLE
adding project policy fixes and enhanced support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 - Adding support for customer codebuild image overrides.  This IS backward-compatible
 - Enable use of generic SEEDFARMER prefixed Env Variables in CodeBuild
 - Example modules demonstrate use of SEEDFARMER generic Env Variables
-- Adding `SeedFarmerProject` `SeedFarmerModule` `SeedFarmerDeployment` tags to module role 
+- Adding `SeedFarmerProject` `SeedFarmerModule` `SeedFarmerDeployment` tags to module role
+- Adding CLI support to synthesize the project policy for modification
+- Add `projectPolicyPath` suppprt to `seedfarmer.yaml` to allow override of default project policy
 
 ### Changes
 - {ProjectName}_PROJECT_NAME and SEEDFARMER_PROJECT_NAME Env Variables added to CodeBuild
@@ -21,6 +23,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 - Fix codebuild role name reference
 - Fix support for project names with `-` characters
 - Error handling around `list` commands when a module is not found
+- Force seedfarmer to ingore project policies in module projects unless configred to use it
 
 
 ## v2.5.0 (2023-02-08)

--- a/docs/source/project_development.md
+++ b/docs/source/project_development.md
@@ -26,7 +26,15 @@ It is important to have the ```seedfarmer.yaml``` at the root of your project.  
 ```yaml
 project: <your project name>
 description: <your project description>
+projectPolicyPath: <relativepath/policyname.yaml>
 ```
+- **project** (REQUIRED) - this is the name of the project that all deployments will reference 
+- **description** (OPTIONAL) - this is the description of the project
+- **projectPolicyPath** (OPTIONAL) - this allows advanced users change the project policy that has the basic minimim permissions seedfarmer needs
+  - it consists of a path relative to the project root and MUST be a valid relative path
+  - to synth the existing project policy, run `seedfarmer projectpolicy synth` 
+
+
 
 (project_initalization)=
 ## Initialization

--- a/seedfarmer/__init__.py
+++ b/seedfarmer/__init__.py
@@ -33,6 +33,7 @@ DEBUG_LOGGING_FORMAT = "[%(asctime)s][%(filename)-13s:%(lineno)3d] %(message)s"
 INFO_LOGGING_FORMAT = "[%(asctime)s | %(levelname)s | %(filename)-13s:%(lineno)3d | %(threadName)s ] %(message)s"
 
 CLI_ROOT = os.path.dirname(os.path.abspath(__file__))
+PROJECT_POLICY_PATH = "resources/projectpolicy.yaml"
 
 
 def enable_debug(format: str) -> None:
@@ -79,6 +80,11 @@ class Config(object):
             config_data: Dict[str, Any] = yaml.safe_load(file)
             self._PROJECT = config_data["project"]
             self._DESCRIPTION = config_data["description"] if "description" in config_data else "NEW PROJECT"
+            self._PROJECT_POLICY_PATH = (
+                os.path.join(self._OPS_ROOT, config_data["projectPolicyPath"])
+                if "projectPolicyPath" in config_data and config_data["projectPolicyPath"] is not None
+                else os.path.join(CLI_ROOT, PROJECT_POLICY_PATH)
+            )
 
         @codeseeder.configure(cast(str, self._PROJECT).lower(), deploy_if_not_exists=True)
         def configure(configuration: CodeSeederConfig) -> None:
@@ -112,6 +118,12 @@ class Config(object):
         if self._OPS_ROOT is None:
             self._load_config_data()
         return str(self._OPS_ROOT)
+
+    @property
+    def PROJECT_POLICY_PATH(self) -> str:
+        if self._PROJECT_POLICY_PATH is None:
+            self._load_config_data()
+        return str(self._PROJECT_POLICY_PATH)
 
 
 config = Config()

--- a/seedfarmer/__main__.py
+++ b/seedfarmer/__main__.py
@@ -22,7 +22,7 @@ from dotenv import load_dotenv
 
 import seedfarmer
 from seedfarmer import DEBUG_LOGGING_FORMAT, commands, config, enable_debug
-from seedfarmer.cli_groups import bootstrap, init, list, remove, store
+from seedfarmer.cli_groups import bootstrap, init, list, projectpolicy, remove, store
 from seedfarmer.output_utils import print_bolded
 
 _logger: logging.Logger = logging.getLogger(__name__)
@@ -233,5 +233,6 @@ def main() -> int:
     cli.add_command(init)
     cli.add_command(version)
     cli.add_command(bootstrap)
+    cli.add_command(projectpolicy)
     cli()
     return 0

--- a/seedfarmer/cli_groups/_project_group.py
+++ b/seedfarmer/cli_groups/_project_group.py
@@ -25,7 +25,7 @@ _logger: logging.Logger = logging.getLogger(__name__)
 
 @click.group(name="projectpolicy", help="Fetch info about the project policy")
 def projectpolicy() -> None:
-    """Bootstrap a Toolchain or Target account"""
+    """Get info about the Project Policy"""
     pass
 
 

--- a/seedfarmer/cli_groups/_project_group.py
+++ b/seedfarmer/cli_groups/_project_group.py
@@ -1,0 +1,43 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License").
+#    You may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+
+import logging
+
+import click
+
+from seedfarmer import DEBUG_LOGGING_FORMAT, enable_debug
+from seedfarmer.commands import get_project_policy
+
+_logger: logging.Logger = logging.getLogger(__name__)
+
+
+@click.group(name="projectpolicy", help="Fetch info about the project policy")
+def projectpolicy() -> None:
+    """Bootstrap a Toolchain or Target account"""
+    pass
+
+
+@projectpolicy.command(
+    name="synth",
+    help="Synth a Project Policy from seed-farmer.",
+)
+@click.option("--debug/--no-debug", default=False, help="Enable detail logging", show_default=True)
+def policy_synth(
+    debug: bool,
+) -> None:
+    if debug:
+        enable_debug(format=DEBUG_LOGGING_FORMAT)
+
+    get_project_policy()

--- a/seedfarmer/commands/__init__.py
+++ b/seedfarmer/commands/__init__.py
@@ -16,6 +16,7 @@ from seedfarmer.commands._bootstrap_commands import bootstrap_target_account, bo
 from seedfarmer.commands._deployment_commands import apply, destroy
 from seedfarmer.commands._module_commands import deploy_module, destroy_module
 from seedfarmer.commands._parameter_commands import generate_export_env_params, generate_export_raw_env_params
+from seedfarmer.commands._project_policy_commands import get_project_policy
 from seedfarmer.commands._stack_commands import (
     deploy_managed_policy_stack,
     deploy_module_stack,
@@ -42,4 +43,5 @@ __all__ = [
     "generate_export_raw_env_params",
     "bootstrap_toolchain_account",
     "bootstrap_target_account",
+    "get_project_policy",
 ]

--- a/seedfarmer/commands/_project_policy_commands.py
+++ b/seedfarmer/commands/_project_policy_commands.py
@@ -12,11 +12,17 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-from seedfarmer.cli_groups._bootstrap_group import bootstrap
-from seedfarmer.cli_groups._init_group import init
-from seedfarmer.cli_groups._list_group import list
-from seedfarmer.cli_groups._project_group import projectpolicy
-from seedfarmer.cli_groups._remove_group import remove
-from seedfarmer.cli_groups._store_group import store
+import os
+import sys
 
-__all__ = ["bootstrap", "init", "list", "remove", "store", "projectpolicy"]
+import yaml
+
+from seedfarmer import CLI_ROOT, PROJECT_POLICY_PATH
+
+
+def get_project_policy() -> None:
+    with open((os.path.join(CLI_ROOT, PROJECT_POLICY_PATH)), "r") as f:
+        policy = yaml.load(f, Loader=yaml.BaseLoader)
+
+    # Need to use yaml.BaseLoader to accommodate the !Ref w/o a custom class
+    yaml.dump(policy, sys.stdout)

--- a/seedfarmer/resources/projectpolicy.yaml
+++ b/seedfarmer/resources/projectpolicy.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Description: "This stack deploys Project deployment policy"
+Description: "This stack deploys the Policy for seed-farmer projects"
 Parameters:
   ProjectName:
     Type: String


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*
- Force seedfarmer to ignore a project-specific policy if none configured...use the one provided in the python packaging.
- Add configuration in seedfarmer.yaml to specify that a custom project policy is to be used
- Add cli support to synthesize the project policy used by default

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
