### PR TITLE
fix: ensure validate and fix scripts use project level configs

### DIFF
--- a/scripts/fix.sh
+++ b/scripts/fix.sh
@@ -29,7 +29,7 @@ do
         shift # Remove $2 from processing
         ;;
         --path)
-        FIX_PATH="${DIR}/../${2}"
+        FIX_PATH="${2}"
         shift # Remove --path from processing
         shift # Remove $2 from processing
         ;;
@@ -40,18 +40,17 @@ do
     esac
 done
 
-cd ${FIX_PATH}
-FIX_PATH=`pwd`
+cd ${DIR}/..
 
-echo "Fixing: ${FIX_PATH}, Language: ${LANGUAGE}"
+echo "Fixing: $(cd "$(dirname "$FIX_PATH")"; pwd)/$(basename "$FIX_PATH"), Language: ${LANGUAGE}"
 
 if [[ $LANGUAGE == "python" ]]; then
     echo "Running isort, black"
-    isort .
-    black .
+    isort ${FIX_PATH}
+    black ${FIX_PATH}
 elif [[ $LANGUAGE == "typescript" ]]; then
     echo "Running prettier"
-    npx prettier --write .
+    npx prettier --write ${FIX_PATH}
 else
     echo "Language: ${LANGUAGE}"
     exit 1

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -34,7 +34,7 @@ do
         shift # Remove --python from processing
         ;;
         --path)
-        VALIDATE_PATH="${DIR}/../${2}"
+        VALIDATE_PATH="${2}"
         shift # Remove --path from processing
         shift # Remove $2 from processing
         ;;
@@ -45,19 +45,18 @@ do
     esac
 done
 
-cd ${VALIDATE_PATH}
-VALIDATE_PATH=`pwd`
+cd ${DIR}/..
 
-echo "Validating: ${VALIDATE_PATH}, Language: ${LANGUAGE}"
+echo "Validating: $(cd "$(dirname "$VALIDATE_PATH")"; pwd)/$(basename "$VALIDATE_PATH"), Language: ${LANGUAGE}"
 
 echo "Validating Formatting"
 if [[ $LANGUAGE == "python" ]]; then
     echo "Checking isort, black"
-    isort --check .
-    black --check .
+    isort --check ${VALIDATE_PATH}
+    black --check ${VALIDATE_PATH}
 elif [[ $LANGUAGE == "typescript" ]]; then
     echo "Checking prettier"
-    npx prettier -c .
+    npx prettier -c ${VALIDATE_PATH}
 else
     echo "ERROR Language: ${LANGUAGE}"
     exit 1
@@ -67,8 +66,8 @@ if [[ $SKIP_STATIC_CHECKS == "false" ]]; then
     echo "Validating Static Checks"
     if [[ $LANGUAGE == "python" ]]; then
         echo "Checking flake8, mypy"
-        flake8 .
-        mypy --ignore-missing-imports .
+        flake8 ${VALIDATE_PATH}
+        mypy --ignore-missing-imports ${VALIDATE_PATH}
     else
         echo "ERROR Language: ${LANGUAGE}"
         exit 1


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*
`fix.sh` and `validate.sh` were incorrectly changing directory into the target and failing to use the project level configs. this update aligns their usage with the github workflows.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
