### PR TITLE
fix: codecommit repos are assumed unsafe by gitpython

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 - removed modules as they now are in `https://github.com/awslabs/seedfarmer-modules`
 
 ### Fixes
-
+- fix for `gitpython` assuming that codecommit repos are unsafe 
 
 ## v2.6.0 (2023-03-10)
 

--- a/seedfarmer/commands/_deployment_commands.py
+++ b/seedfarmer/commands/_deployment_commands.py
@@ -69,6 +69,10 @@ def _clone_module_repo(git_path: str) -> str:
     str
         The local directory within the codeseeder.out/ where the repository was cloned
     """
+    # gitpython library has started blocking non https and ssh protocols by default
+    # codecommit is not _actually_ unsafe
+    allow_unsafe_protocols = git_path.startswith("git::codecommit")
+
     git_path = git_path.replace("git::", "")
     ref: Optional[str] = None
     depth: Optional[int] = None
@@ -92,10 +96,10 @@ def _clone_module_repo(git_path: str) -> str:
     os.makedirs(working_dir, exist_ok=True)
     if not os.listdir(working_dir):
         _logger.debug("Cloning %s into %s: ref=%s depth=%s", git_path, working_dir, ref, depth)
-        Repo.clone_from(git_path, working_dir, branch=ref, depth=depth)
+        Repo.clone_from(git_path, working_dir, branch=ref, depth=depth, allow_unsafe_protocols=allow_unsafe_protocols)
     else:
         _logger.debug("Pulling existing repo %s at %s: ref=%s", git_path, working_dir, ref)
-        Repo(working_dir).remotes["origin"].pull()
+        Repo(working_dir).remotes["origin"].pull(allow_unsafe_protocols=allow_unsafe_protocols)
 
     return os.path.join(working_dir, module_directory)
 


### PR DESCRIPTION
*Issue #, if available:* Fixes #269

*Description of changes:*
- Because latest versions of `gitpython` assume that non https or ssh git repo protocols are unsafe and causes failure on codecommit clone/pull, we allow unsafe protocols if codecommit repo is detected

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
