### PR TITLE
adding version eval on ssm and secretsmanager for checksum totals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ### New
 
 ### Changes
+- adding support for evaluating the version of SSM and secretsmanager when calculating md5 of code (for redeploy)
 
 ### Fixes
 

--- a/seedfarmer/commands/_deployment_commands.py
+++ b/seedfarmer/commands/_deployment_commands.py
@@ -520,29 +520,26 @@ def deploy_deployment(
 
             for param in module.parameters:
                 if param.value_from and param.value_from.parameter_store:
-                    param.version = int(
-                        mi.get_ssm_parameter_version(
-                            ssm_parameter_name=param.value_from.parameter_store,
-                            session=SessionManager()
-                            .get_or_create()
-                            .get_deployment_session(
-                                account_id=cast(str, module.get_target_account_id()),
-                                region_name=cast(str, module.target_region),
-                            ),
-                        )
+
+                    param.version = mi.get_ssm_parameter_version(
+                        ssm_parameter_name=param.value_from.parameter_store,
+                        session=SessionManager()
+                        .get_or_create()
+                        .get_deployment_session(
+                            account_id=cast(str, module.get_target_account_id()),
+                            region_name=cast(str, module.target_region),
+                        ),
                     )
 
                 elif param.value_from and param.value_from.secrets_manager:
-                    param.version = str(
-                        mi.get_secrets_parameter_version(
-                            secret_parameter_name=param.value_from.secrets_manager,
-                            session=SessionManager()
-                            .get_or_create()
-                            .get_deployment_session(
-                                account_id=cast(str, module.get_target_account_id()),
-                                region_name=cast(str, module.target_region),
-                            ),
-                        )
+                    param.version = mi.get_secrets_parameter_version(
+                        secret_parameter_name=param.value_from.secrets_manager,
+                        session=SessionManager()
+                        .get_or_create()
+                        .get_deployment_session(
+                            account_id=cast(str, module.get_target_account_id()),
+                            region_name=cast(str, module.target_region),
+                        ),
                     )
 
             module.manifest_md5 = hashlib.md5(json.dumps(module.dict(), sort_keys=True).encode("utf-8")).hexdigest()

--- a/seedfarmer/commands/_deployment_commands.py
+++ b/seedfarmer/commands/_deployment_commands.py
@@ -532,8 +532,16 @@ def deploy_deployment(
                     )
 
                 elif param.value_from and param.value_from.secrets_manager:
-                    param.version = mi.get_secrets_parameter_version(
-                        secret_parameter_name=param.value_from.secrets_manager,
+                    param_name = param.value_from.secrets_manager
+                    version_ref = None
+                    if ":" in param_name:
+                        parsed = param_name.split(":")
+                        param_name = parsed[0]
+                        version_ref = parsed[2] if len(parsed) == 3 else None
+
+                    param.version = mi.get_secrets_version(
+                        secret_name=param_name,
+                        version_ref=version_ref,
                         session=SessionManager()
                         .get_or_create()
                         .get_deployment_session(

--- a/seedfarmer/commands/_deployment_commands.py
+++ b/seedfarmer/commands/_deployment_commands.py
@@ -520,7 +520,10 @@ def deploy_deployment(
 
             for param in module.parameters:
                 if param.value_from and param.value_from.parameter_store:
-
+                    if ":" in param.value_from.parameter_store:
+                        raise Exception(
+                            f"CodeBuild does not support Versioned SSM Parameters -- see {group_name}-{module.name}"
+                        )
                     param.version = mi.get_ssm_parameter_version(
                         ssm_parameter_name=param.value_from.parameter_store,
                         session=SessionManager()

--- a/seedfarmer/commands/_deployment_commands.py
+++ b/seedfarmer/commands/_deployment_commands.py
@@ -25,6 +25,7 @@ from git import Repo  # type: ignore
 
 import seedfarmer.checksum as checksum
 import seedfarmer.mgmt.deploy_utils as du
+import seedfarmer.mgmt.module_info as mi
 from seedfarmer import commands, config
 from seedfarmer.commands._parameter_commands import load_parameter_values
 from seedfarmer.mgmt.module_info import (
@@ -516,6 +517,34 @@ def deploy_deployment(
                 module_path=str(module.get_local_path()),
                 excluded_files=md5_excluded_module_files,
             )
+
+            for param in module.parameters:
+                if param.value_from and param.value_from.parameter_store:
+                    param.version = int(
+                        mi.get_ssm_parameter_version(
+                            ssm_parameter_name=param.value_from.parameter_store,
+                            session=SessionManager()
+                            .get_or_create()
+                            .get_deployment_session(
+                                account_id=cast(str, module.get_target_account_id()),
+                                region_name=cast(str, module.target_region),
+                            ),
+                        )
+                    )
+
+                elif param.value_from and param.value_from.secrets_manager:
+                    param.version = str(
+                        mi.get_secrets_parameter_version(
+                            secret_parameter_name=param.value_from.secrets_manager,
+                            session=SessionManager()
+                            .get_or_create()
+                            .get_deployment_session(
+                                account_id=cast(str, module.get_target_account_id()),
+                                region_name=cast(str, module.target_region),
+                            ),
+                        )
+                    )
+
             module.manifest_md5 = hashlib.md5(json.dumps(module.dict(), sort_keys=True).encode("utf-8")).hexdigest()
             module.deployspec_md5 = hashlib.md5(open(deployspec_path, "rb").read()).hexdigest()
 

--- a/seedfarmer/commands/_stack_commands.py
+++ b/seedfarmer/commands/_stack_commands.py
@@ -18,7 +18,7 @@ import os
 import time
 from typing import Any, List, Optional, Tuple
 
-from aws_codeseeder import EnvVar, codeseeder, commands, services
+from aws_codeseeder import EnvVar, EnvVarType, codeseeder, commands, services
 from cfn_tools import load_yaml
 
 import seedfarmer.services._iam as iam
@@ -273,7 +273,13 @@ def deploy_module_stack(
                 elif isinstance(value, list):
                     stack_parameters[k] = ",".join(value)
                 elif isinstance(value, EnvVar):
-                    stack_parameters[k] = value.value
+                    if (
+                        value.type in [EnvVarType.PARAMETER_STORE.value, EnvVarType.SECRETS_MANAGER.value]
+                        and ":" in value.value
+                    ):
+                        stack_parameters[k] = value.value.split(":")[0]
+                    else:
+                        stack_parameters[k] = value.value
                 else:
                     json.dumps(value)
         _logger.debug("stack_parameters: %s", stack_parameters)

--- a/seedfarmer/mgmt/module_info.py
+++ b/seedfarmer/mgmt/module_info.py
@@ -347,6 +347,30 @@ def get_secret_secrets_manager(name: str, session: Optional[Session] = None) -> 
     return secrets.get_secret_secrets_manager(name=name, session=session)
 
 
+def get_secrets_parameter_version(
+    secret_parameter_name: str,
+    session: Optional[Session] = None,
+) -> str:
+    version = secrets.get_current_version(name=secret_parameter_name, session=session)
+    if version is None:
+        _logger.error("The Secrets Manager parameter %s could not be fetched", secret_parameter_name)
+        raise Exception("The Secrets Manager parameter could not be fetched")
+    else:
+        return str(version)
+
+
+def get_ssm_parameter_version(
+    ssm_parameter_name: str,
+    session: Optional[Session] = None,
+) -> int:
+    version = ssm.get_current_version(name=ssm_parameter_name, session=session)
+    if version is None:
+        _logger.error("The SSM parameter %s could not be fetched", ssm_parameter_name)
+        raise Exception("The SSM parameter could not be fetched")
+    else:
+        return int(version)
+
+
 def get_group_manifest(
     deployment: str, group: str, params_cache: Optional[Dict[str, Any]] = None, session: Optional[Session] = None
 ) -> Optional[Dict[str, Any]]:

--- a/seedfarmer/models/manifests/_module_manifest.py
+++ b/seedfarmer/models/manifests/_module_manifest.py
@@ -26,6 +26,7 @@ class ModuleParameter(ValueFromRef):
 
     name: str
     value: Optional[Any] = None
+    version: Optional[Any] = None
 
     def __init__(self, **data: Any) -> None:
         super().__init__(**data)

--- a/seedfarmer/resources/deployment_role.template
+++ b/seedfarmer/resources/deployment_role.template
@@ -82,7 +82,7 @@ Resources:
             - Action:
               - iam:ListPolicies
               - ssm:DescribeParameters
-              - secretsmanager:DescribeSecret
+              - secretsmanager:ListSecretVersionIds
               - codebuild:ListProjects
               - cloudformation:Describe*
               - cloudformation:GetTemplate

--- a/seedfarmer/resources/deployment_role.template
+++ b/seedfarmer/resources/deployment_role.template
@@ -82,6 +82,7 @@ Resources:
             - Action:
               - iam:ListPolicies
               - ssm:DescribeParameters
+              - secretsmanager:DescribeSecret
               - codebuild:ListProjects
               - cloudformation:Describe*
               - cloudformation:GetTemplate

--- a/seedfarmer/services/_secrets_manager.py
+++ b/seedfarmer/services/_secrets_manager.py
@@ -25,3 +25,13 @@ def get_secret_secrets_manager(name: str, session: Optional[Session] = None) -> 
     secret_arn = f"arn:aws:secretsmanager:{get_region(session=session)}:{get_account_id(session=session)}:secret:{name}"
     json_str: str = client.get_secret_value(SecretId=secret_arn).get("SecretString")
     return cast(Dict[str, Any], json.loads(json_str))
+
+
+def get_current_version(name: str, session: Optional[Session] = None) -> Optional[str]:
+    client = boto3_client(service_name="secretsmanager", session=session)
+    secret_arn = f"arn:aws:secretsmanager:{get_region(session=session)}:{get_account_id(session=session)}:secret:{name}"
+    resp = client.describe_secret(SecretId=secret_arn)
+    for version_entry in resp["VersionIdsToStages"]:
+        if "AWSCURRENT" in resp["VersionIdsToStages"].get(version_entry):
+            return str(version_entry)
+    return None

--- a/seedfarmer/services/_secrets_manager.py
+++ b/seedfarmer/services/_secrets_manager.py
@@ -13,7 +13,7 @@
 #    limitations under the License.
 
 import json
-from typing import Any, Dict, Optional, cast
+from typing import Any, Dict, List, Optional, cast
 
 from boto3 import Session
 
@@ -27,7 +27,8 @@ def get_secrets_manager_value(name: str, session: Optional[Session] = None) -> D
     return cast(Dict[str, Any], json.loads(json_str))
 
 
-def describe_secret(name: str, session: Optional[Session] = None) -> Optional[Any]:
+def list_secret_version_ids(name: str, session: Optional[Session] = None) -> Optional[List[Any]]:
     client = boto3_client(service_name="secretsmanager", session=session)
     secret_arn = f"arn:aws:secretsmanager:{get_region(session=session)}:{get_account_id(session=session)}:secret:{name}"
-    return client.describe_secret(SecretId=secret_arn)
+    resp = client.list_secret_version_ids(SecretId=secret_arn)
+    return client.list_secret_version_ids(SecretId=secret_arn)["Versions"] if resp else None

--- a/seedfarmer/services/_secrets_manager.py
+++ b/seedfarmer/services/_secrets_manager.py
@@ -20,18 +20,14 @@ from boto3 import Session
 from seedfarmer.services._service_utils import boto3_client, get_account_id, get_region
 
 
-def get_secret_secrets_manager(name: str, session: Optional[Session] = None) -> Dict[str, Any]:
+def get_secrets_manager_value(name: str, session: Optional[Session] = None) -> Dict[str, Any]:
     client = boto3_client(service_name="secretsmanager", session=session)
     secret_arn = f"arn:aws:secretsmanager:{get_region(session=session)}:{get_account_id(session=session)}:secret:{name}"
     json_str: str = client.get_secret_value(SecretId=secret_arn).get("SecretString")
     return cast(Dict[str, Any], json.loads(json_str))
 
 
-def get_current_version(name: str, session: Optional[Session] = None) -> Optional[str]:
+def describe_secret(name: str, session: Optional[Session] = None) -> Optional[Any]:
     client = boto3_client(service_name="secretsmanager", session=session)
     secret_arn = f"arn:aws:secretsmanager:{get_region(session=session)}:{get_account_id(session=session)}:secret:{name}"
-    resp = client.describe_secret(SecretId=secret_arn)
-    for version_entry in resp["VersionIdsToStages"]:
-        if "AWSCURRENT" in resp["VersionIdsToStages"].get(version_entry):
-            return str(version_entry)
-    return None
+    return client.describe_secret(SecretId=secret_arn)

--- a/seedfarmer/services/_ssm.py
+++ b/seedfarmer/services/_ssm.py
@@ -149,3 +149,21 @@ def delete_parameters(parameters: List[str], session: Optional[Session] = None) 
         else:
             delete_parameters(parameters[0:9], session=session)
             delete_parameters(parameters[9:], session=session)
+
+
+def get_current_version(name: str, session: Optional[Session] = None) -> Optional[int]:
+    client = boto3_client(service_name="ssm", session=session)
+    resp = client.describe_parameters(
+        ParameterFilters=[
+            {
+                "Key": "Type",
+                "Option": "Equals",
+                "Values": [
+                    "String",
+                ],
+            },
+            {"Key": "Name", "Option": "Equals", "Values": [name]},
+        ],
+    )
+
+    return (resp["Parameters"][0]["Version"]) if len(resp["Parameters"]) > 0 else None

--- a/seedfarmer/services/_ssm.py
+++ b/seedfarmer/services/_ssm.py
@@ -151,9 +151,9 @@ def delete_parameters(parameters: List[str], session: Optional[Session] = None) 
             delete_parameters(parameters[9:], session=session)
 
 
-def get_current_version(name: str, session: Optional[Session] = None) -> Optional[int]:
+def describe_parameter(name: str, session: Optional[Session] = None) -> Optional[Any]:
     client = boto3_client(service_name="ssm", session=session)
-    resp = client.describe_parameters(
+    return client.describe_parameters(
         ParameterFilters=[
             {
                 "Key": "Type",
@@ -165,5 +165,3 @@ def get_current_version(name: str, session: Optional[Session] = None) -> Optiona
             {"Key": "Name", "Option": "Equals", "Values": [name]},
         ],
     )
-
-    return (resp["Parameters"][0]["Version"]) if len(resp["Parameters"]) > 0 else None

--- a/test/unit-test/test_mgmt_module_info.py
+++ b/test/unit-test/test_mgmt_module_info.py
@@ -380,3 +380,40 @@ def test_fetch_helper(aws_credentials,session,mocker):
     mi._fetch_helper(name="myapp", session=session)
 
     mi._fetch_helper(name="myapp",params_cache={"myapp":"yo"}, session=session)
+    
+    
+@pytest.mark.mgmt
+@pytest.mark.mgmt_module_info
+def test_get_secrets_parameter_version(aws_credentials,session,mocker):
+    import seedfarmer.mgmt.module_info as mi
+    mocker.patch("seedfarmer.mgmt.module_info.secrets.get_current_version", return_value="fdsfasfioasofasf")
+    val = mi.get_secrets_parameter_version("sometest",session=session)
+    
+    assert val == "fdsfasfioasofasf"
+    
+@pytest.mark.mgmt
+@pytest.mark.mgmt_module_info
+def test_get_secrets_parameter_version_failure(aws_credentials,session,mocker):
+    import seedfarmer.mgmt.module_info as mi
+    mocker.patch("seedfarmer.mgmt.module_info.secrets.get_current_version", return_value=None)
+    with pytest.raises(Exception):
+        mi.get_secrets_parameter_version("sometest",session=session)
+    
+    
+    
+@pytest.mark.mgmt
+@pytest.mark.mgmt_module_info
+def test_get_ssm_parameter_version(aws_credentials,session,mocker):
+    import seedfarmer.mgmt.module_info as mi
+    mocker.patch("seedfarmer.mgmt.module_info.ssm.get_current_version", return_value=5)
+    val = mi.get_ssm_parameter_version("sometest",session=session)
+    
+    assert val == 5
+    
+@pytest.mark.mgmt
+@pytest.mark.mgmt_module_info
+def test_get_ssm_parameter_version_failure(aws_credentials,session,mocker):
+    import seedfarmer.mgmt.module_info as mi
+    mocker.patch("seedfarmer.mgmt.module_info.ssm.get_current_version", return_value=None)
+    with pytest.raises(Exception):
+        mi.get_ssm_parameter_version("sometest",session=session)

--- a/test/unit-test/test_mgmt_module_info.py
+++ b/test/unit-test/test_mgmt_module_info.py
@@ -386,16 +386,37 @@ def test_fetch_helper(aws_credentials,session,mocker):
 @pytest.mark.mgmt_module_info
 def test_get_secrets_parameter_version(aws_credentials,session,mocker):
     import seedfarmer.mgmt.module_info as mi
-    mocker.patch("seedfarmer.mgmt.module_info.secrets.get_current_version", return_value="fdsfasfioasofasf")
+    test_json = {
+            "ARN": "arn:aws:secretsmanager:us-east-1:123456789012:secret:testderek-oFFYl7",
+            "Name": "testderek",
+            "VersionIdsToStages": {
+                "2b872dd3-f8dc-42db-acce-19055abb4bd5": ["AWSCURRENT"]
+            },
+            "ResponseMetadata": {
+                "RequestId": "a6eec7fc-a844-4744-ad26-558e7a4884dc",
+                "HTTPStatusCode": 200,
+                "HTTPHeaders": {
+                "x-amzn-requestid": "a6eec7fc-a844-4744-ad26-558e7a4884dc",
+                "content-type": "application/x-amz-json-1.1",
+                "content-length": "272",
+                "date": "Tue, 18 Apr 2023 00:13:58 GMT"
+                },
+                "RetryAttempts": 0
+            }
+            }
+    
+    
+    
+    mocker.patch("seedfarmer.mgmt.module_info.secrets.describe_secret", return_value=test_json)
     val = mi.get_secrets_parameter_version("sometest",session=session)
     
-    assert val == "fdsfasfioasofasf"
+    assert val == "2b872dd3-f8dc-42db-acce-19055abb4bd5"
     
 @pytest.mark.mgmt
 @pytest.mark.mgmt_module_info
 def test_get_secrets_parameter_version_failure(aws_credentials,session,mocker):
     import seedfarmer.mgmt.module_info as mi
-    mocker.patch("seedfarmer.mgmt.module_info.secrets.get_current_version", return_value=None)
+    mocker.patch("seedfarmer.mgmt.module_info.secrets.describe_secret", return_value=None)
     with pytest.raises(Exception):
         mi.get_secrets_parameter_version("sometest",session=session)
     
@@ -405,7 +426,36 @@ def test_get_secrets_parameter_version_failure(aws_credentials,session,mocker):
 @pytest.mark.mgmt_module_info
 def test_get_ssm_parameter_version(aws_credentials,session,mocker):
     import seedfarmer.mgmt.module_info as mi
-    mocker.patch("seedfarmer.mgmt.module_info.ssm.get_current_version", return_value=5)
+    test_json = {
+            "Parameters": [
+                {
+                "Name": "testingversioning",
+                "Type": "String",
+                "LastModifiedUser": "arn:aws:sts::123456789012:assumed-role/Admin/someone-Isengard",
+                "Version": 5,
+                "Tier": "Standard",
+                "Policies": [],
+                "DataType": "text"
+                }
+            ],
+            "ResponseMetadata": {
+                "RequestId": "693a5834-1802-4aa1-8254-879f942e9f5b",
+                "HTTPStatusCode": 200,
+                "HTTPHeaders": {
+                "server": "Server",
+                "date": "Mon, 17 Apr 2023 23:45:53 GMT",
+                "content-type": "application/x-amz-json-1.1",
+                "content-length": "243",
+                "connection": "keep-alive",
+                "x-amzn-requestid": "693a5834-1802-4aa1-8254-879f942e9f5b"
+                },
+                "RetryAttempts": 0
+            }
+            }
+    
+    
+    
+    mocker.patch("seedfarmer.mgmt.module_info.ssm.describe_parameter", return_value=test_json)
     val = mi.get_ssm_parameter_version("sometest",session=session)
     
     assert val == 5
@@ -414,6 +464,6 @@ def test_get_ssm_parameter_version(aws_credentials,session,mocker):
 @pytest.mark.mgmt_module_info
 def test_get_ssm_parameter_version_failure(aws_credentials,session,mocker):
     import seedfarmer.mgmt.module_info as mi
-    mocker.patch("seedfarmer.mgmt.module_info.ssm.get_current_version", return_value=None)
+    mocker.patch("seedfarmer.mgmt.module_info.ssm.describe_parameter", return_value=None)
     with pytest.raises(Exception):
         mi.get_ssm_parameter_version("sometest",session=session)

--- a/test/unit-test/test_mgmt_module_info.py
+++ b/test/unit-test/test_mgmt_module_info.py
@@ -381,46 +381,92 @@ def test_fetch_helper(aws_credentials,session,mocker):
 
     mi._fetch_helper(name="myapp",params_cache={"myapp":"yo"}, session=session)
     
-    
-@pytest.mark.mgmt
-@pytest.mark.mgmt_module_info
-def test_get_secrets_parameter_version(aws_credentials,session,mocker):
-    import seedfarmer.mgmt.module_info as mi
-    test_json = {
-            "ARN": "arn:aws:secretsmanager:us-east-1:123456789012:secret:testderek-oFFYl7",
-            "Name": "testderek",
-            "VersionIdsToStages": {
-                "2b872dd3-f8dc-42db-acce-19055abb4bd5": ["AWSCURRENT"]
+
+secrets_manager_mock_data = {
+        "Versions": [
+            {
+                "VersionId": "17853545-211c-461b-938c-6f9bf36652ce",
+                "VersionStages": [
+                    "AWSPREVIOUS",
+                    "WTFTESTING"
+                ],
+                "LastAccessedDate": "2023-04-17 20:00:00-04:00",
+                "CreatedDate": "2023-04-17 20:52:11.327000-04:00",
+                "KmsKeyIds": [
+                    "DefaultEncryptionKey"
+                ]
             },
-            "ResponseMetadata": {
-                "RequestId": "a6eec7fc-a844-4744-ad26-558e7a4884dc",
-                "HTTPStatusCode": 200,
-                "HTTPHeaders": {
-                "x-amzn-requestid": "a6eec7fc-a844-4744-ad26-558e7a4884dc",
+            {
+                "VersionId": "3ae24b7a-a4dc-4ee3-ba47-ef4969c1e687",
+                "VersionStages": [
+                    "USEME",
+                    "AWSCURRENT"
+                ],
+                "LastAccessedDate": "2023-04-17 20:00:00-04:00",
+                "CreatedDate": "2023-04-17 20:53:26.644000-04:00",
+                "KmsKeyIds": [
+                    "DefaultEncryptionKey"
+                ]
+            }
+        ],
+        "ARN": "arn:aws:secretsmanager:us-east-1:123456789012:secret:testderekaddf-QZHkSe",
+        "Name": "testderekaddf",
+        "ResponseMetadata": {
+            "RequestId": "078d54ce-4005-43ad-af49-722dd1016e36",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "078d54ce-4005-43ad-af49-722dd1016e36",
                 "content-type": "application/x-amz-json-1.1",
-                "content-length": "272",
-                "date": "Tue, 18 Apr 2023 00:13:58 GMT"
-                },
-                "RetryAttempts": 0
-            }
-            }
-    
-    
-    
-    mocker.patch("seedfarmer.mgmt.module_info.secrets.describe_secret", return_value=test_json)
-    val = mi.get_secrets_parameter_version("sometest",session=session)
-    
-    assert val == "2b872dd3-f8dc-42db-acce-19055abb4bd5"
+                "content-length": "505",
+                "date": "Tue, 18 Apr 2023 02:06:29 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+
     
 @pytest.mark.mgmt
 @pytest.mark.mgmt_module_info
-def test_get_secrets_parameter_version_failure(aws_credentials,session,mocker):
+def test_get_secrets_version_with_version_id(aws_credentials,session,mocker):
     import seedfarmer.mgmt.module_info as mi
-    mocker.patch("seedfarmer.mgmt.module_info.secrets.describe_secret", return_value=None)
-    with pytest.raises(Exception):
-        mi.get_secrets_parameter_version("sometest",session=session)
     
+    mocker.patch("seedfarmer.mgmt.module_info.secrets.list_secret_version_ids", 
+                 return_value=secrets_manager_mock_data['Versions'])
     
+    val = mi.get_secrets_version(secret_name="sometest",
+                                 version_ref="17853545-211c-461b-938c-6f9bf36652ce",
+                                 session=session)
+    
+    assert val == "17853545-211c-461b-938c-6f9bf36652ce"
+    
+@pytest.mark.mgmt
+@pytest.mark.mgmt_module_info
+def test_get_secrets_version_with_no_ref(aws_credentials,session,mocker):
+    import seedfarmer.mgmt.module_info as mi
+    
+    mocker.patch("seedfarmer.mgmt.module_info.secrets.list_secret_version_ids", 
+                 return_value=secrets_manager_mock_data['Versions'])
+    
+    val = mi.get_secrets_version(secret_name="sometest",
+                                 session=session)
+    
+    assert val == "3ae24b7a-a4dc-4ee3-ba47-ef4969c1e687"
+
+
+@pytest.mark.mgmt
+@pytest.mark.mgmt_module_info
+def test_get_secrets_version_with_status(aws_credentials,session,mocker):
+    import seedfarmer.mgmt.module_info as mi
+    
+    mocker.patch("seedfarmer.mgmt.module_info.secrets.list_secret_version_ids", 
+                 return_value=secrets_manager_mock_data['Versions'])
+    
+    val = mi.get_secrets_version(secret_name="sometest:username",
+                                 version_ref="USEME",
+                                 session=session)
+    
+    assert val == "3ae24b7a-a4dc-4ee3-ba47-ef4969c1e687"
+        
     
 @pytest.mark.mgmt
 @pytest.mark.mgmt_module_info

--- a/test/unit-test/test_services.py
+++ b/test/unit-test/test_services.py
@@ -210,6 +210,15 @@ def test_delete_ssm_param(session) -> None:
         )
 
 
+@pytest.mark.service
+def test_get_ssm_current_version(session) -> None:
+    import seedfarmer.services._ssm as ssm
+
+    with mock_ssm():
+        ssm.put_parameter(name="/myapp/test/", obj={"Hey": "testing"}, session=session)
+        ssm.get_current_version(name="/myapp/test/", session=session)
+
+
 # ### SecretsManager
 # @pytest.mark.service
 # def test_secrets_manager(session_manager, mocker, secretsmanager_client)->None:

--- a/test/unit-test/test_services.py
+++ b/test/unit-test/test_services.py
@@ -211,12 +211,12 @@ def test_delete_ssm_param(session) -> None:
 
 
 @pytest.mark.service
-def test_get_ssm_current_version(session) -> None:
+def test_get_ssm_metadata(session) -> None:
     import seedfarmer.services._ssm as ssm
 
     with mock_ssm():
         ssm.put_parameter(name="/myapp/test/", obj={"Hey": "testing"}, session=session)
-        ssm.get_current_version(name="/myapp/test/", session=session)
+        ssm.describe_parameter(name="/myapp/test/", session=session)
 
 
 # ### SecretsManager


### PR DESCRIPTION
*Issue #, if available:*
#295 

*Description of changes:*
Adding in evaluating of SSM version and SecretsManager version when calculating md5 for redeploy logic.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
