### PR TITLE
adding synth output for templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ### New
 
 ### Changes
-
+- adding synth for both bootstrap templates when issuing `--as-target`
 ### Fixes
 
 

--- a/seedfarmer/commands/_bootstrap_commands.py
+++ b/seedfarmer/commands/_bootstrap_commands.py
@@ -61,8 +61,13 @@ def get_deployment_template(
     return dict(json.loads(t))
 
 
-def write_template(template: Dict[Any, Any]) -> None:
+def write_template(template: Dict[Any, Any], description: Optional[str] = None) -> None:
+    if description:
+        print(description)
+        print("")
+
     yaml.dump(template, sys.stdout)
+    print("")
 
 
 def bootstrap_toolchain_account(
@@ -90,7 +95,17 @@ def bootstrap_toolchain_account(
                 session=session,
             )
     else:
-        write_template(template=template)
+        write_template(template=template, description="The Toolchain Template")
+        if as_target:
+            bootstrap_target_account(
+                toolchain_account_id="123456789012",
+                project_name=project_name,
+                permissions_boundary_arn=permissions_boundary_arn,
+                profile=profile,
+                region_name=region_name,
+                session=None,
+                synthesize=synthesize,
+            )
     return template
 
 
@@ -114,7 +129,7 @@ def bootstrap_target_account(
         )
         apply_deploy_logic(template=template, role_name=role_name, stack_name=stack_name, session=session)
     else:
-        write_template(template=template)
+        write_template(template=template, description="The Target Template")
     return template
 
 


### PR DESCRIPTION
*Issue #, if available:*
#307 
*Description of changes:*
When generating bootstrap templates via `--synth`, outputing both templates if `--as-target` is passed in

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
