### PR TITLE
refactoring deployment_commands, adding unittests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 - added python upper limit versioning (to `<3.12`)
 
 ### Fixes
+- typo in messaging about errored manifest
 
 ## v2.6.5 (2023-05-03)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ### New
 
 ### Changes
+- refactored deployment_commands
+- added python upper limit versioning (to `<3.12`)
 
 ### Fixes
 

--- a/seedfarmer/commands/_deployment_commands.py
+++ b/seedfarmer/commands/_deployment_commands.py
@@ -703,7 +703,7 @@ def apply(
             except Exception as e:
                 _logger.error(e)
                 _logger.error(f"Cannot parse a file at {os.path.join(config.OPS_ROOT, module_group.path)}")
-                _logger.error("Verify that elemts are filled out and yaml compliant")
+                _logger.error("Verify that elements are filled out and yaml compliant")
                 exit(1)
     deployment_manifest.validate_and_set_module_defaults()
 

--- a/seedfarmer/commands/_deployment_commands.py
+++ b/seedfarmer/commands/_deployment_commands.py
@@ -124,7 +124,7 @@ def _process_data_files(data_files: List[DataFile], module_name: str, group_name
         for missing_file in missing_files:
             print(f"  {missing_file}")
         print_bolded(message="Exiting Deployment", color="red")
-        exit(1)
+        raise ValueError("Missing DataFiles - cannot process")
 
 
 def _execute_deploy(
@@ -273,7 +273,7 @@ def _deploy_validated_deployment(
             _print_modules(
                 f"Modules scheduled to be deployed (created or updated): {deployment_manifest.name}", mods_would_deploy
             )
-            exit(0)
+            return
         deployment_manifest_wip.groups = groups_to_deploy
         print_manifest_inventory(
             f"Modules scheduled to be deployed (created or updated): {deployment_manifest_wip.name}",
@@ -704,7 +704,7 @@ def apply(
                 _logger.error(e)
                 _logger.error(f"Cannot parse a file at {os.path.join(config.OPS_ROOT, module_group.path)}")
                 _logger.error("Verify that elements are filled out and yaml compliant")
-                exit(1)
+                raise ValueError("Cannot parse manifest file path")
     deployment_manifest.validate_and_set_module_defaults()
 
     prime_target_accounts(deployment_manifest=deployment_manifest)
@@ -721,7 +721,7 @@ def apply(
             header_message="The following modules requested for destroy have dependencies that prevent destruction:",
             errored_list=violations,
         )
-        exit(1)
+        raise Exception("Modules cannot be destroyed due to dependencies")
 
     destroy_deployment(
         destroy_manifest=destroy_manifest,

--- a/seedfarmer/mgmt/deploy_utils.py
+++ b/seedfarmer/mgmt/deploy_utils.py
@@ -173,7 +173,7 @@ def validate_group_parameters(group: ModulesManifest) -> None:
           No module can refer to its own group for parameter lookups!!
         """
         print_bolded(message=message, color="red")
-        exit(1)
+        raise ValueError(message)
 
 
 def validate_module_dependencies(

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     license=about["__license__"],
     packages=find_packages(include=["seed-farmer", "seedfarmer", "seedfarmer.*", "seed-farmer.*"]),
     keywords=["aws", "cdk"],
-    python_requires=">=3.7",
+    python_requires=">=3.7,<3.12",
     install_requires=[
         "aws-codeseeder~=0.9.0",
         "cookiecutter~=2.1.0",

--- a/test/unit-test/test_commands_deployment.py
+++ b/test/unit-test/test_commands_deployment.py
@@ -72,9 +72,8 @@ def test_apply_violations(session_manager,mocker):
     mocker.patch("seedfarmer.commands._deployment_commands.du.filter_deploy_destroy", return_value=None)
     mocker.patch("seedfarmer.commands._deployment_commands.write_deployment_manifest", return_value=None)
     mocker.patch("seedfarmer.commands._deployment_commands.du.validate_module_dependencies", return_value=[{"module1":["moduleA","moduleB"]}])
-    with pytest.raises(SystemExit) as pytest_wrapped_e:
+    with pytest.raises(Exception):
         dc.apply(deployment_manifest_path="test/unit-test/mock_data/manifests/module-test/deployment-hc.yaml")
-    assert pytest_wrapped_e.type == SystemExit
     
 
 @pytest.mark.commands
@@ -142,10 +141,8 @@ def test_process_data_files_error(mocker):
     datafile_list =[]
     datafile_list.append(DataFile(file_path=git_path_test))
     datafile_list.append(DataFile(file_path=""))
-    with pytest.raises(SystemExit) as missing_error:
+    with pytest.raises(ValueError):
         dc._process_data_files(data_files=datafile_list, module_name="test",group_name="test")
-        
-    assert missing_error.value.code == 1
     
     
     

--- a/test/unit-test/test_mgmt_deploy_utils.py
+++ b/test/unit-test/test_mgmt_deploy_utils.py
@@ -19,7 +19,7 @@ import yaml
 
 import pytest
 import seedfarmer.mgmt.deploy_utils as du
-from seedfarmer.models.manifests import DeploymentManifest, ModulesManifest
+from seedfarmer.models.manifests import DeploymentManifest, ModulesManifest, DataFile
 from seedfarmer.services._service_utils import boto3_client
 from seedfarmer.services.session_manager import SessionManager
 import mock_data.mock_manifests as mock_manifests
@@ -261,3 +261,10 @@ def test_validate_module_dependencies():
                                     destroy_manifest=DeploymentManifest(**mock_deployment_manifest_for_destroy.destroy_manifest)
         
     )
+    
+@pytest.mark.mgmt
+@pytest.mark.mgmt_deployment_utils_filter   
+def test_validate_datafiles():
+
+    files = DataFile(file_path="")
+    du.validate_data_files(data_files=[files])

--- a/test/unit-test/test_mgmt_deploy_utils.py
+++ b/test/unit-test/test_mgmt_deploy_utils.py
@@ -80,11 +80,8 @@ def test_validate_group_parameters():
 @pytest.mark.mgmt_deployment_utils
 def test_validate_group_parameters_failure():
     manifest = ModulesManifest(**mock_manifests.modules_manifest_duplicate)
-    with pytest.raises(SystemExit) as dupe_error:
-        du.validate_group_parameters(manifest)
-        
-    assert dupe_error.value.code == 1
-    
+    with pytest.raises(ValueError):
+        du.validate_group_parameters(manifest)    
   
 @pytest.mark.mgmt
 @pytest.mark.mgmt_deployment_utils


### PR DESCRIPTION
*Issue #, if available:*
#323 
*Description of changes:*

- Removed `dry_run` method naming conventions from deployment_commands 
- added unittests 
- added upper python version limit
- fixed typo in messaging

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
