### PR TITLE
adding all moduledata list support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ## Unreleased
 
 ### New
+- adding `seedfarmer list allmoduledata` to fetch all the metadata in a deployment in a single call
 
 ### Changes
 

--- a/test/unit-test/test_cli_arg.py
+++ b/test/unit-test/test_cli_arg.py
@@ -546,6 +546,22 @@ def test_list_moduledata_non_existent_module():
     )
 
 
+@pytest.mark.list
+@pytest.mark.list_moduledata
+def test_list_all_moduledata(session_manager,mocker):
+    mocker.patch("seedfarmer.cli_groups._list_group.du.generate_deployed_manifest", return_value=(DeploymentManifest(**mock_manifests.deployment_manifest)))
+    mocker.patch("seedfarmer.cli_groups._list_group.mi.get_module_metadata",return_value=mock_manifests.sample_metadata)
+
+    _test_command(
+        sub_command=list,
+        options=[
+            "allmoduledata",
+            "-d","test",
+            "-p","myapp",
+            "--debug",
+            ],
+        exit_code=0,
+    )
 
 # # Test `list modules` #
 


### PR DESCRIPTION
*Issue #, if available:*
#326 
#328 

*Description of changes:*
Adding CLI command `seedfarmer list allmoduledata` to fetch a dict of all deployed modules metadata

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
