### PR TITLE
adding support for ssm param that is a string only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ### Changes
 
 ### Fixes
+- allow for SSM parameter to be either string or json-compliant when a single value
 
 ## v2.7.0 (2023-05-16)
 

--- a/docs/source/manifests.md
+++ b/docs/source/manifests.md
@@ -105,8 +105,8 @@ In the above section, we defined VPC support for deployments in CodeBuild.  The 
   
 
 There are a couple of things to be aware of:
-1. The three values (vpcID, privateSubnetIds, securityGroupIds) should be stored as a string (if a vpcId) or stringified JSON lists (if privateSubnetIds or securityGroupIds).  These constructs are not flexible.  SeedFarmer predominantly leverages JSON or YAML and strings - these values are no different.
-2. Each value is defined independently - and is in no way linked to the other 2.  It is up to you (the end user) to make sure the Subnets / Security Groups are in the proper VPC.  SeedFarmer does NOT validate this prior, and the deployment will error out with an ugly stack trace.
+1. The three values (vpcID, privateSubnetIds, securityGroupIds) should be stored as a string (if a vpcId) or stringified JSON lists (if privateSubnetIds or securityGroupIds).  **SeedFarmer predominantly leverages JSON as strings stored in SSM - these values are no different**.
+2. Each value is defined independently - and is in no way linked to the other two.  It is up to you (the end user) to make sure the Subnets / Security Groups are in the proper VPC.  SeedFarmer does NOT validate this prior, and the deployment will error out with an ugly stack trace.
 
 Lets look as some examples
 #### HardCoded Value Support for Network

--- a/docs/source/manifests.md
+++ b/docs/source/manifests.md
@@ -105,7 +105,7 @@ In the above section, we defined VPC support for deployments in CodeBuild.  The 
   
 
 There are a couple of things to be aware of:
-1. The three values (vpcID, privateSubnetIds, securityGroupIds) should be stored as a string (if a vpcId) or stringified JSON lists (if privateSubnetIds or securityGroupIds).  **SeedFarmer predominantly leverages JSON as strings stored in SSM - these values are no different**.
+1. The three values (vpcId, privateSubnetIds, securityGroupIds) should be stored as a string (if a vpcId) or stringified JSON lists (if privateSubnetIds or securityGroupIds).  **SeedFarmer predominantly leverages JSON as strings stored in SSM - these values are no different**.
 2. Each value is defined independently - and is in no way linked to the other two.  It is up to you (the end user) to make sure the Subnets / Security Groups are in the proper VPC.  SeedFarmer does NOT validate this prior, and the deployment will error out with an ugly stack trace.
 
 Lets look as some examples

--- a/seedfarmer/services/_ssm.py
+++ b/seedfarmer/services/_ssm.py
@@ -50,7 +50,11 @@ def put_parameter(name: str, obj: Dict[str, Any], session: Optional[Session] = N
 def get_parameter(name: str, session: Optional[Session] = None) -> Dict[str, Any]:
     client = boto3_client(service_name="ssm", session=session)
     json_str: str = client.get_parameter(Name=name)["Parameter"]["Value"]
-    return cast(Dict[str, Any], json.loads(json_str))
+    try:
+        return cast(Dict[str, Any], json.loads(json_str))
+    except json.decoder.JSONDecodeError:
+        _logger.warn("Parameter %s cannot be parsed, returning it as-is - %s ", name, json_str)
+        return cast(Dict[str, Any], json_str)
 
 
 def get_parameter_if_exists(name: str, session: Optional[Session] = None) -> Optional[Dict[str, Any]]:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When using a vpc-id defined in SSM for Networks, the parameter can now be a json-string (`"vpc-233243"`) or just an element (`vpc-233243`)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
