### PR TITLE
adding support for policy attach to bootstrap target role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 
 ### New
 - adding qualifier support for bootstrap roles
+- adding support to attach policies to target role when bootstrapping
 
 ### Changes
 

--- a/docs/source/bootstrapping.md
+++ b/docs/source/bootstrapping.md
@@ -13,7 +13,8 @@ Usage: seedfarmer bootstrap toolchain [OPTIONS]
 Options:
   -p, --project TEXT              Project identifier
   -t, --trusted-principal TEXT    ARN of Principals trusted to assume the
-                                  Toolchain Role
+                                  Toolchain Role.  This can be used multiple
+                                  times to create a list.
   -b, --permissions-boundary TEXT
                                   ARN of a Managed Policy to set as the
                                   Permission Boundary on the Toolchain Role
@@ -23,7 +24,12 @@ Options:
                                   deploy  [default: no-synth]
   --profile TEXT                  The AWS profile to initiate a session
   --region TEXT                   AWS region to use
-  --qualifier TEXT                A qualifier to append to toolchain role (alpha-numeric char max length of 6)
+  --qualifier TEXT                A qualifier to append to toolchain role
+                                  (alpha-numeric char max length of 6)
+  -pa, --policy-arn TEXT          ARN of existing Policy to attach to Target
+                                  Role (Deploymenmt Role) This can be use
+                                  multiple times, but EACH policy MUST be
+                                  valid in the Target Account
   --debug / --no-debug            Enable detail logging  [default: no-debug]
   --help                          Show this message and exit.
 ```
@@ -54,7 +60,12 @@ Options:
                                   deploy  [default: no-synth]
   --profile TEXT                  The AWS profile to initiate a session
   --region TEXT                   AWS region to use
-  --qualifier TEXT                A qualifier to append to target role (alpha-numeric char max length of 6)
+  --qualifier TEXT                A qualifier to append to target role (alpha-
+                                  numeric char max length of 6)
+  -pa, --policy-arn TEXT          ARN of existing Policy to attach to Target
+                                  Role (Deploymenmt Role) This can be use
+                                  multiple times to create a list, but EACH
+                                  policy MUST be valid in the Target Account
   --debug / --no-debug            Enable detail logging  [default: no-debug]
   --help                          Show this message and exit.
 ```

--- a/docs/source/bootstrapping.md
+++ b/docs/source/bootstrapping.md
@@ -13,7 +13,7 @@ Usage: seedfarmer bootstrap toolchain [OPTIONS]
 Options:
   -p, --project TEXT              Project identifier
   -t, --trusted-principal TEXT    ARN of Principals trusted to assume the
-                                  Toolchain Role.  This can be used multiple
+                                  Toolchain Role. This can be used multiple
                                   times to create a list.
   -b, --permissions-boundary TEXT
                                   ARN of a Managed Policy to set as the
@@ -29,7 +29,10 @@ Options:
   -pa, --policy-arn TEXT          ARN of existing Policy to attach to Target
                                   Role (Deploymenmt Role) This can be use
                                   multiple times, but EACH policy MUST be
-                                  valid in the Target Account
+                                  valid in the Target Account. The `--as-
+                                  target` flag must be used if passing in
+                                  policy arns as they are applied to the
+                                  Deployment Role only.
   --debug / --no-debug            Enable detail logging  [default: no-debug]
   --help                          Show this message and exit.
 ```

--- a/seedfarmer/cli_groups/_bootstrap_group.py
+++ b/seedfarmer/cli_groups/_bootstrap_group.py
@@ -105,7 +105,9 @@ def bootstrap() -> None:
     "--policy-arn",
     "-pa",
     help="""ARN of existing Policy to attach to Target Role (Deploymenmt Role)
-    This can be use multiple times, but EACH policy MUST be valid in the Target Account""",
+    This can be use multiple times, but EACH policy MUST be valid in the Target Account.
+    The `--as-target` flag must be used if passing in policy arns as they are applied to
+    the Deployment Role only.""",
     multiple=True,
     required=False,
     default=[],
@@ -129,7 +131,7 @@ def bootstrap_toolchain(
         project = _load_project()
     _logger.debug("Bootstrapping a Toolchain account for Project %s", project)
     if len(policy_arn) > 0 and not as_target:  # type: ignore
-        raise click.ClickException("Cannot set PolicyARNS and not set the -as-target flag")
+        raise click.ClickException("Cannot set PolicyARNS when the `-as-target` flag is not set.")
 
     bootstrap_toolchain_account(
         project_name=project,

--- a/seedfarmer/commands/_bootstrap_commands.py
+++ b/seedfarmer/commands/_bootstrap_commands.py
@@ -53,13 +53,18 @@ def get_toolchain_template(
 
 
 def get_deployment_template(
-    toolchain_role_arn: str, project_name: str, role_name: str, permissions_boundary_arn: Optional[str] = None
+    toolchain_role_arn: str,
+    project_name: str,
+    role_name: str,
+    policy_arns: Optional[List[str]],
+    permissions_boundary_arn: Optional[str] = None,
 ) -> Dict[Any, Any]:
     with open((os.path.join(CLI_ROOT, "resources/deployment_role.template")), "r") as f:
         role = yaml.safe_load(f)
     if permissions_boundary_arn:
         role["Resources"]["DeploymentRole"]["Properties"]["PermissionsBoundary"] = permissions_boundary_arn
-
+    if policy_arns:
+        role["Resources"]["DeploymentRole"]["Properties"]["ManagedPolicyArns"] = policy_arns
     template = Template(json.dumps(role))
     t = template.render(
         {"toolchain_role_arn": toolchain_role_arn, "project_name": project_name, "role_name": role_name}
@@ -76,6 +81,7 @@ def bootstrap_toolchain_account(
     project_name: str,
     principal_arns: List[str],
     permissions_boundary_arn: Optional[str] = None,
+    policy_arns: Optional[List[str]] = None,
     qualifier: Optional[str] = None,
     profile: Optional[str] = None,
     region_name: Optional[str] = None,
@@ -105,6 +111,7 @@ def bootstrap_toolchain_account(
                 permissions_boundary_arn=permissions_boundary_arn,
                 profile=profile,
                 region_name=region_name,
+                policy_arns=policy_arns,
                 session=session,
             )
     else:
@@ -115,6 +122,7 @@ def bootstrap_toolchain_account(
                 project_name=project_name,
                 qualifier=cast(str, qualifier),
                 permissions_boundary_arn=permissions_boundary_arn,
+                policy_arns=policy_arns,
                 profile=profile,
                 region_name=region_name,
                 session=None,
@@ -131,6 +139,7 @@ def bootstrap_target_account(
     profile: Optional[str] = None,
     region_name: Optional[str] = None,
     session: Optional[Session] = None,
+    policy_arns: Optional[List[str]] = None,
     synthesize: bool = False,
 ) -> Optional[Dict[Any, Any]]:
 
@@ -146,6 +155,7 @@ def bootstrap_target_account(
         toolchain_role_arn=toolchain_role_arn,
         project_name=project_name,
         role_name=role_stack_name,
+        policy_arns=policy_arns if policy_arns else None,
         permissions_boundary_arn=permissions_boundary_arn,
     )
     _logger.debug((json.dumps(template, indent=4)))

--- a/test/unit-test/test_cli_arg.py
+++ b/test/unit-test/test_cli_arg.py
@@ -209,27 +209,6 @@ def test_bootstrap_toolchain_only_with_qualifier(mocker):
 
 
 @pytest.mark.bootstrap
-def test_bootstrap_toolchain_only_with_policies(mocker):
-    # Bootstrap an Account As Target
-    mocker.patch("seedfarmer.commands._bootstrap_commands.bootstrap_target_account", return_value=None)
-    mocker.patch("seedfarmer.commands._bootstrap_commands.bootstrap_toolchain_account", return_value=None)
-    mocker.patch("seedfarmer.commands._bootstrap_commands.apply_deploy_logic", return_value=None)
-    _test_command(
-        sub_command=bootstrap,
-        options=[
-            "toolchain",
-            "--trusted-principal",
-            "arn:aws:iam::123456789012:role/AdminRole",
-            "-pa",
-            "arn:aws:iam::aws:policy/AdministratorAccess",
-            "--as-target",
-            "--debug",
-        ],
-        exit_code=0,
-    )
-
-
-@pytest.mark.bootstrap
 def test_bootstrap_toolchain_only_with_policies_fail(mocker):
     # Bootstrap an Account As Target
     mocker.patch("seedfarmer.commands._bootstrap_commands.bootstrap_target_account", return_value=None)

--- a/test/unit-test/test_cli_arg.py
+++ b/test/unit-test/test_cli_arg.py
@@ -189,6 +189,67 @@ def test_bootstrap_toolchain_only(mocker):
 
 
 @pytest.mark.bootstrap
+def test_bootstrap_toolchain_only_with_qualifier(mocker):
+    # Bootstrap an Account As Target
+    mocker.patch("seedfarmer.commands._bootstrap_commands.bootstrap_target_account", return_value=None)
+    mocker.patch("seedfarmer.commands._bootstrap_commands.bootstrap_toolchain_account", return_value=None)
+    mocker.patch("seedfarmer.commands._bootstrap_commands.apply_deploy_logic", return_value=None)
+    _test_command(
+        sub_command=bootstrap,
+        options=[
+            "toolchain",
+            "--trusted-principal",
+            "arn:aws:iam::123456789012:role/AdminRole",
+            "--qualifier",
+            "testit",
+            "--debug",
+        ],
+        exit_code=0,
+    )
+
+
+@pytest.mark.bootstrap
+def test_bootstrap_toolchain_only_with_policies(mocker):
+    # Bootstrap an Account As Target
+    mocker.patch("seedfarmer.commands._bootstrap_commands.bootstrap_target_account", return_value=None)
+    mocker.patch("seedfarmer.commands._bootstrap_commands.bootstrap_toolchain_account", return_value=None)
+    mocker.patch("seedfarmer.commands._bootstrap_commands.apply_deploy_logic", return_value=None)
+    _test_command(
+        sub_command=bootstrap,
+        options=[
+            "toolchain",
+            "--trusted-principal",
+            "arn:aws:iam::123456789012:role/AdminRole",
+            "-pa",
+            "arn:aws:iam::aws:policy/AdministratorAccess",
+            "--as-target",
+            "--debug",
+        ],
+        exit_code=0,
+    )
+
+
+@pytest.mark.bootstrap
+def test_bootstrap_toolchain_only_with_policies_fail(mocker):
+    # Bootstrap an Account As Target
+    mocker.patch("seedfarmer.commands._bootstrap_commands.bootstrap_target_account", return_value=None)
+    mocker.patch("seedfarmer.commands._bootstrap_commands.bootstrap_toolchain_account", return_value=None)
+    mocker.patch("seedfarmer.commands._bootstrap_commands.apply_deploy_logic", return_value=None)
+    _test_command(
+        sub_command=bootstrap,
+        options=[
+            "toolchain",
+            "--trusted-principal",
+            "arn:aws:iam::123456789012:role/AdminRole",
+            "-pa",
+            "arn:aws:iam::aws:policy/AdministratorAccess",
+            "--debug",
+        ],
+        exit_code=1,
+    )
+
+
+@pytest.mark.bootstrap
 def test_bootstrap_target_account(mocker):
     # Bootstrap an Account As Target
     mocker.patch("seedfarmer.commands._bootstrap_commands.bootstrap_target_account", return_value=None)
@@ -196,6 +257,19 @@ def test_bootstrap_target_account(mocker):
     mocker.patch("seedfarmer.commands._bootstrap_commands.apply_deploy_logic", return_value=None)
     _test_command(
         sub_command=bootstrap, options=["target", "--toolchain-account", "123456789012", "--debug"], exit_code=0
+    )
+
+
+@pytest.mark.bootstrap
+def test_bootstrap_target_account_with_qualifier(mocker):
+    # Bootstrap an Account As Target
+    mocker.patch("seedfarmer.commands._bootstrap_commands.bootstrap_target_account", return_value=None)
+    mocker.patch("seedfarmer.commands._bootstrap_commands.bootstrap_toolchain_account", return_value=None)
+    mocker.patch("seedfarmer.commands._bootstrap_commands.apply_deploy_logic", return_value=None)
+    _test_command(
+        sub_command=bootstrap,
+        options=["target", "--toolchain-account", "123456789012", "--qualifier", "testit", "--debug"],
+        exit_code=0,
     )
 
 

--- a/test/unit-test/test_commands_bootstrap.py
+++ b/test/unit-test/test_commands_bootstrap.py
@@ -192,6 +192,24 @@ def test_bootstrap_toolchain_account_synth_with_qualifier_fail(mocker, session):
 @pytest.mark.commands
 @pytest.mark.commands_bootstrap
 @pytest.mark.parametrize("session", [boto3.Session()])
+def test_bootstrap_toolchain_account_with_policies(mocker, session):
+
+    mocker.patch("seedfarmer.commands._bootstrap_commands.apply_deploy_logic", return_value="")
+    mocker.patch("seedfarmer.commands._bootstrap_commands.bootstrap_target_account", return_value="")
+    bc.bootstrap_toolchain_account(
+        project_name="testing",
+        principal_arns=["arn:aws:iam::123456789012:role/AdminRole"],
+        policy_arns=["arn:aws:iam::aws:policy/AdministratorAccess", "arn:aws:iam::aws:policy/ReadOnlyAccess"],
+        permissions_boundary_arn=None,
+        region_name="us-east-1",
+        synthesize=False,
+        as_target=False,
+    )
+
+
+@pytest.mark.commands
+@pytest.mark.commands_bootstrap
+@pytest.mark.parametrize("session", [boto3.Session()])
 def test_bootstrap_target_account(mocker, session):
     mocker.patch("seedfarmer.commands._bootstrap_commands.apply_deploy_logic", return_value="")
     bc.bootstrap_target_account(
@@ -235,3 +253,19 @@ def test_bootstrap_target_account_with_qualifier_fail(mocker, session):
             synthesize=False,
             session=session,
         )
+
+
+@pytest.mark.commands
+@pytest.mark.commands_bootstrap
+@pytest.mark.parametrize("session", [boto3.Session()])
+def test_bootstrap_target_account_with_policies(mocker, session):
+    mocker.patch("seedfarmer.commands._bootstrap_commands.apply_deploy_logic", return_value="")
+    bc.bootstrap_target_account(
+        toolchain_account_id="123456789012",
+        project_name="testing",
+        policy_arns=["arn:aws:iam::aws:policy/AdministratorAccess", "arn:aws:iam::aws:policy/ReadOnlyAccess"],
+        permissions_boundary_arn=None,
+        region_name="us-east-1",
+        synthesize=False,
+        session=session,
+    )


### PR DESCRIPTION
*Issue #, if available:*
#352 

*Description of changes:*
Adding ability to pass in an attach managed policies to deployment roles on bootstrap

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
