### PR TITLE
raise error if metadata or valuefrom parameter is none

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 - adding qualifier support for bootstrap roles
 
 ### Changes
-
+- raise error if a metadata parameter or value_from parameter is not available
 ### Fixes
 
 ## v2.8.0 (2023-05-23)

--- a/test/unit-test/test_commands_parameters.py
+++ b/test/unit-test/test_commands_parameters.py
@@ -206,6 +206,7 @@ def test_load_parameter_values(session_manager, mocker):
     assert ("vpc-id" in names) == True
     assert ("test-secrets-manager" in names) == True
     assert ("test-ssm-store" in names) == True
+    assert ("test-regional-param" in names) == True
 
 
 @pytest.mark.commands


### PR DESCRIPTION
*Issue #, if available:*
#355 

*Description of changes:*
Whenever using a parameter source from metadata or from global/regional parameters and it is not found, raise an error

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
