### PR TITLE
adding error handling for cloned repos based off tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 
 ### Fixes
 - handle exceptions when cloned repo based off tags is in a detached HEAD state
+- proper parsing of modulestack.yaml path if sourced from git
 
 ## v2.9.0 (2023-06-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ### Changes
 
 ### Fixes
+- handle exceptions when cloned repo based off tags is in a detached HEAD state
 
 ## v2.9.0 (2023-06-16)
 

--- a/seedfarmer/commands/_deployment_commands.py
+++ b/seedfarmer/commands/_deployment_commands.py
@@ -22,7 +22,7 @@ from urllib.parse import parse_qs
 
 import git.exc
 import yaml
-from git import Repo
+from git import Repo  # type: ignore
 
 import seedfarmer.checksum as checksum
 import seedfarmer.errors
@@ -105,7 +105,7 @@ def _clone_module_repo(git_path: str) -> Tuple[str, str]:
         _logger.debug("Pulling existing repo %s at %s: ref=%s", git_path, working_dir, ref)
         try:
             Repo(working_dir).remotes["origin"].pull(allow_unsafe_protocols=allow_unsafe_protocols)
-        except git.exc.GitCommandError as e:
+        except git.exc.GitCommandError as e:  # type: ignore
             _logger.warn(f"  {e}")
             _logger.warn("This local code is in a detached HEAD state and cannot pull, moving on")
 

--- a/seedfarmer/commands/_deployment_commands.py
+++ b/seedfarmer/commands/_deployment_commands.py
@@ -22,7 +22,7 @@ from urllib.parse import parse_qs
 
 import git.exc
 import yaml
-from git import Repo  # type: ignore
+from git import Repo
 
 import seedfarmer.checksum as checksum
 import seedfarmer.errors

--- a/seedfarmer/mgmt/module_info.py
+++ b/seedfarmer/mgmt/module_info.py
@@ -813,6 +813,8 @@ def get_module_stack_names(
 
 
 def get_modulestack_path(module_path: str) -> Any:
+    module_path = module_path.split(".git//")[1].split("?")[0] if module_path.startswith("git::") else module_path
+    module_path = module_path[:-1] if module_path.endswith("/") else module_path
     p = os.path.join(config.OPS_ROOT, module_path, "modulestack.yaml")
     if not os.path.exists(p):
         _logger.debug("No modulestack.yaml found")

--- a/test/unit-test/test_mgmt_module_info.py
+++ b/test/unit-test/test_mgmt_module_info.py
@@ -327,6 +327,15 @@ def test_get_modulestack_path():
 
 @pytest.mark.mgmt
 @pytest.mark.mgmt_module_info
+def test_get_modulestack_path_from_git():
+    import seedfarmer.mgmt.module_info as mi
+
+    gitpath = "git::https://github.com/awslabs/idf-modules.git//modules/replication/dockerimage-replication?ref=v2.0.0"
+    mi.get_modulestack_path(module_path=gitpath)
+
+
+@pytest.mark.mgmt
+@pytest.mark.mgmt_module_info
 def test_get_deployspec_path():
     import seedfarmer.mgmt.module_info as mi
 


### PR DESCRIPTION
*Issue #, if available:*
#362 

*Description of changes:*
When using a tag as a source for the cloned git repo, subsequent use of the repo errors on pull due to being in a detached HEAD state.  We are catching that error and moving on as the local repo based on the tag is already up to date with the latest code...no need to pull.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
