### PR TITLE
consistently apply evaluation of local paths to get modulestack path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ### New
 
 ### Changes
+- applying local path eval consistently, updating patch release 2.9.1 chnage for modulestack.yaml eval
 
 ### Fixes
 

--- a/seedfarmer/commands/_deployment_commands.py
+++ b/seedfarmer/commands/_deployment_commands.py
@@ -155,7 +155,7 @@ def _execute_deploy(
     target_region = cast(str, module_manifest.target_region)
     # Deploys the IAM role per module
     module_stack_name, module_role_name = commands.deploy_module_stack(
-        get_modulestack_path(module_manifest.get_local_path()),
+        get_modulestack_path(str(module_manifest.get_local_path())),
         cast(str, deployment_manifest.name),
         group_name,
         module_manifest.name,

--- a/seedfarmer/commands/_deployment_commands.py
+++ b/seedfarmer/commands/_deployment_commands.py
@@ -155,7 +155,7 @@ def _execute_deploy(
     target_region = cast(str, module_manifest.target_region)
     # Deploys the IAM role per module
     module_stack_name, module_role_name = commands.deploy_module_stack(
-        get_modulestack_path(module_manifest.path),
+        get_modulestack_path(module_manifest.get_local_path()),
         cast(str, deployment_manifest.name),
         group_name,
         module_manifest.name,

--- a/seedfarmer/mgmt/module_info.py
+++ b/seedfarmer/mgmt/module_info.py
@@ -813,8 +813,6 @@ def get_module_stack_names(
 
 
 def get_modulestack_path(module_path: str) -> Any:
-    module_path = module_path.split(".git//")[1].split("?")[0] if module_path.startswith("git::") else module_path
-    module_path = module_path[:-1] if module_path.endswith("/") else module_path
     p = os.path.join(config.OPS_ROOT, module_path, "modulestack.yaml")
     if not os.path.exists(p):
         _logger.debug("No modulestack.yaml found")

--- a/test/unit-test/test_mgmt_module_info.py
+++ b/test/unit-test/test_mgmt_module_info.py
@@ -327,15 +327,6 @@ def test_get_modulestack_path():
 
 @pytest.mark.mgmt
 @pytest.mark.mgmt_module_info
-def test_get_modulestack_path_from_git():
-    import seedfarmer.mgmt.module_info as mi
-
-    gitpath = "git::https://github.com/awslabs/idf-modules.git//modules/replication/dockerimage-replication?ref=v2.0.0"
-    mi.get_modulestack_path(module_path=gitpath)
-
-
-@pytest.mark.mgmt
-@pytest.mark.mgmt_module_info
 def test_get_deployspec_path():
     import seedfarmer.mgmt.module_info as mi
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Patch release 2.9.1 implemented evaluation of local path to get modulestack.yaml in an inconsistent manner.  This change applies the eval consistently by referencing the manifest.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
