### PR TITLE
fxing code-commit repo pull functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ### Changes
 
 ### Fixes
+- updated how remote repos are created and pulled to support code-commit
 
 ## v2.9.3 (2023-06-28)
 

--- a/seedfarmer/commands/_deployment_commands.py
+++ b/seedfarmer/commands/_deployment_commands.py
@@ -20,6 +20,7 @@ import os
 from typing import Any, Dict, List, Optional, Tuple, cast
 from urllib.parse import parse_qs
 
+import git  # type: ignore
 import yaml
 from git import Repo  # type: ignore
 
@@ -101,7 +102,7 @@ def _clone_module_repo(git_path: str) -> Tuple[str, str]:
         if ref is not None:
             _logger.debug("Creating local repo and setting remote: %s into %s: ref=%s ", git_path, working_dir, ref)
             repo = Repo.init(working_dir)
-            repo.create_remote("origin", git_path)
+            git.Remote.create(repo, "origin", git_path, allow_unsafe_protocols)
             repo.remotes["origin"].pull(ref, allow_unsafe_protocols=allow_unsafe_protocols)
         else:
             _logger.debug("Cloning %s into %s: ref=%s depth=%s", git_path, working_dir, ref, depth)

--- a/seedfarmer/commands/_deployment_commands.py
+++ b/seedfarmer/commands/_deployment_commands.py
@@ -20,7 +20,7 @@ import os
 from typing import Any, Dict, List, Optional, Tuple, cast
 from urllib.parse import parse_qs
 
-import git  # type: ignore
+import git
 import yaml
 from git import Repo  # type: ignore
 


### PR DESCRIPTION
*Issue #, if available:*
#376
*Description of changes:*
The exposed method of created a local repo from a remote did not have access to the allow-unsafe-protocols that code-commit needed.  This PR uses a lower-level method to support.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
