### PR TITLE
fix policy arn for dockersecret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ### Changes
 
 ### Fixes
+- correct the arn generation of inline policy for docker secrets policy
 
 ## v2.10.0 (2023-07-21)
 

--- a/seedfarmer/commands/_stack_commands.py
+++ b/seedfarmer/commands/_stack_commands.py
@@ -338,7 +338,7 @@ def deploy_module_stack(
                         "secretsmanager:ListSecretVersionIds",
                     ],
                     "Resource": (
-                        f"arn::{deployment_partition}:secretsmanager:{region}:{account_id}"
+                        f"arn:{deployment_partition}:secretsmanager:{region}:{account_id}"
                         f":secret:{docker_credentials_secret}*"
                     ),
                 },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The arn of the inline policy for the docker secret support had a typo

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
