### PR TITLE
forcing proper urllib3 dependency version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -113,5 +113,6 @@ urllib3==1.26.15
     # via
     #   botocore
     #   requests
+    #   seed-farmer (setup.py)
 verboselogs==1.7
     # via property-manager

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,8 @@ setup(
         "python-dotenv~=0.21.0",
         "gitpython~=3.1.30",
         "gitignore-parser~=0.1.2",
-        "pyyaml~=6.0.1"
+        "pyyaml~=6.0.1",
+        "urllib3==1.26.15"
     ],
     entry_points={"console_scripts": ["seedfarmer = seedfarmer.__main__:main"]},
     classifiers=[


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The urllib3 that is installed does not support botocore, forcing the proper version to install.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
