### PR TITLE
allow not-json module params to be parsed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 - adding `concurrency` definition to the docs
 - updating `urllib==1.26.5` in docs/requirements-docs.in
 - adding in seedkit redeploy information in the `Architecture` section of the docs
-
+- allow non-json compliant ssm parameters to be parsed when using module-specifics paths (`/<project>/<dep>/<mod>/databaseinfo`)
 ### Fixes
 
 ## v2.10.2 (2023-07-28)

--- a/seedfarmer/services/_ssm.py
+++ b/seedfarmer/services/_ssm.py
@@ -141,7 +141,11 @@ def get_all_parameter_data_by_path(prefix: str, session: Optional[Session] = Non
     ret: Dict[str, Dict[str, Any]] = {}
     for page in response_iterator:
         for par in page.get("Parameters"):
-            ret[par["Name"]] = json.loads(par["Value"])
+            try:
+                ret[par["Name"]] = json.loads(par["Value"])
+            except json.decoder.JSONDecodeError:
+                _logger.warn("Parameter %s cannot be parsed, returning it as-is", par["Name"])
+                ret[par["Name"]] = par["Value"]
     return ret
 
 


### PR DESCRIPTION
*Issue #, if available:*
#420 

*Description of changes:*
When using paths in SSM that correspond to a modules`/<project>/<dep>/<module>/somethingnotseedfarmer` allow the param to be passed even if not JSON.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
