### PR TITLE
adding support for cdkv2 prototype in init of modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ### New
 
 ### Changes
+- adding support for module-type spec on init of new module `seedfarmer init module -mt cdkv2`
 
 ### Fixes
 

--- a/seedfarmer/cli_groups/_init_group.py
+++ b/seedfarmer/cli_groups/_init_group.py
@@ -57,7 +57,7 @@ def init_project(template_url: str) -> None:
     "--module-type",
     "-mt",
     type=str,
-    help="The type of module coce deployed...only 'cdkv2' is accepted if used here",
+    help="The type of module code deployed...only 'cdkv2' is accepted if used here",
     required=False,
     default=None,
 )

--- a/seedfarmer/cli_groups/_init_group.py
+++ b/seedfarmer/cli_groups/_init_group.py
@@ -54,6 +54,14 @@ def init_project(template_url: str) -> None:
 )
 @click.option("--module-name", "-m", type=str, help="The module name", required=True)
 @click.option(
+    "--module-type",
+    "-mt",
+    type=str,
+    help="The type of module coce deployed...only 'cdkv2' is accepted if used here",
+    required=False,
+    default=None,
+)
+@click.option(
     "--template-url",
     "-t",
     default="https://github.com/awslabs/seed-farmer.git",
@@ -63,7 +71,7 @@ def init_project(template_url: str) -> None:
     required=False,
 )
 @click.option("--debug/--no-debug", default=False, help="Enable detail logging", show_default=True)
-def init_module(group_name: str, module_name: str, template_url: str, debug: bool) -> None:
+def init_module(group_name: str, module_name: str, module_type: str, template_url: str, debug: bool) -> None:
     if debug:
         enable_debug(format=DEBUG_LOGGING_FORMAT)
     _logger.debug("Initializing module %s", module_name)
@@ -71,5 +79,6 @@ def init_module(group_name: str, module_name: str, template_url: str, debug: boo
     minit.create_module_dir(
         group_name=group_name,
         module_name=module_name,
+        module_type=module_type,
         template_url=template_url,
     )

--- a/seedfarmer/mgmt/module_init.py
+++ b/seedfarmer/mgmt/module_init.py
@@ -24,17 +24,22 @@ from seedfarmer import config
 _logger: logging.Logger = logging.getLogger(__name__)
 
 
-def create_module_dir(module_name: str, group_name: Optional[str], template_url: Optional[str]) -> None:
+def create_module_dir(
+    module_name: str, group_name: Optional[str], module_type: Optional[str], template_url: Optional[str]
+) -> None:
     """Initializes a directory for a new module.
 
     Creates a new directory that contains files that will aid in setting up a development environment
 
     Parameters
     ----------
-    group_name : str
+    group_name : Optional[str],
         Nmae of the group where the module will reside. If group is a nested dir, use `/` as a delimiter
     module_name : str
         Name of the module. The initialization will include project files pulled from the template_url
+    module_type: Optional[str]
+        They type of code the module deploys with, adding more boilerplate code
+        -- only cdkv2 is supported here
     template_url : Optional[List[str]]
         A URL, for example a Github repo, that is or contains templating for the initialization
     """
@@ -53,7 +58,8 @@ def create_module_dir(module_name: str, group_name: Optional[str], template_url:
     if os.path.exists(module_path):
         raise seedfarmer.errors.InvalidPathError(f"The module {module_name} already exists under {output_dir}.")
 
-    checkout_branch = "init-module" if template_url == "https://github.com/awslabs/seed-farmer.git" else None
+    if template_url == "https://github.com/awslabs/seed-farmer.git":
+        checkout_branch = "init-module-cdkv2" if module_type == "cdkv2" else "init-module"
 
     _logger.info("New module will be created in the following dir: %s", output_dir)
     cookiecutter(

--- a/test/unit-test/test_mgmt.py
+++ b/test/unit-test/test_mgmt.py
@@ -47,12 +47,33 @@ def test_module_init():
     import seedfarmer.mgmt.module_init as mi
 
     mi.create_module_dir(
-        module_name="mytestmodule", group_name="mygroup", template_url="https://github.com/awslabs/seed-farmer.git"
+        module_name="mytestmodule", group_name="mygroup", module_type=None, template_url="https://github.com/awslabs/seed-farmer.git"
     )
 
     with pytest.raises(Exception) as e:
         mi.create_module_dir(
-            module_name="mytestmodule", group_name="mygroup", template_url="https://github.com/awslabs/seed-farmer.git"
+            module_name="mytestmodule", group_name="mygroup", module_type=None, template_url="https://github.com/awslabs/seed-farmer.git"
+        )
+
+    assert "module mytestmodule already exists" in str(e)
+
+    shutil.rmtree(setup_mod_dir)
+    
+@pytest.mark.mgmt
+def test_module_init_cdkv2():
+    setup_mod_dir = os.path.join(pathlib.Path(os.getcwd()), "modules")
+
+    if os.path.isdir(setup_mod_dir):
+        shutil.rmtree(setup_mod_dir)
+    import seedfarmer.mgmt.module_init as mi
+
+    mi.create_module_dir(
+        module_name="mytestmodule", group_name="mygroup", module_type="cdkv2", template_url="https://github.com/awslabs/seed-farmer.git"
+    )
+
+    with pytest.raises(Exception) as e:
+        mi.create_module_dir(
+            module_name="mytestmodule", group_name="mygroup", module_type="cdkv2", template_url="https://github.com/awslabs/seed-farmer.git"
         )
 
     assert "module mytestmodule already exists" in str(e)


### PR DESCRIPTION
*Issue #, if available:*
#442 
*Description of changes:*
Adding parameterize input to `seedfarmer init module` to create a cdkv2 module with boilerplate code

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
