### PR TITLE
adding resolved env and global params to checksum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ## Unreleased
 
 ### New
+- BREAKING CHANGE*** - the checksum calculation used to trigger module redeploy has changed
+- Existing deployed modules may incur a redeployment when going from a previous version
+  - resolve global/regional parameters when calculating checksum for individual module redeploy
+  - resolve env parameters when calculating checksum for individual module redeploy
 
 ### Changes
 

--- a/seedfarmer/models/manifests/_module_manifest.py
+++ b/seedfarmer/models/manifests/_module_manifest.py
@@ -27,6 +27,7 @@ class ModuleParameter(ValueFromRef):
     name: str
     value: Optional[Any] = None
     version: Optional[Any] = None
+    resolved_value: Optional[Any] = None
 
     def __init__(self, **data: Any) -> None:
         super().__init__(**data)


### PR DESCRIPTION
*Issue #, if available:*
#451 
*Description of changes:*
Added module manifest attribute (`resolved`) to store the resolved env and global/regional parameters for use in checksum calc - to force a module redeploy if the env variable used or the global/regional parameter used has changed.

This is a breaking change that will cause modules deployed via older seedfarmer versions to incur a redeploy if any parameters (env or global/regional) are referenced.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
