### PR TITLE
force attach managed policy on destroy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ### New
 
 ### Changes
+- force attach the managed policy to the module role during `destroy`
 
 ### Fixes
 

--- a/seedfarmer/commands/__init__.py
+++ b/seedfarmer/commands/__init__.py
@@ -25,6 +25,7 @@ from seedfarmer.commands._stack_commands import (
     destroy_managed_policy_stack,
     destroy_module_stack,
     destroy_seedkit,
+    force_manage_policy_attach,
     get_module_stack_info,
 )
 
@@ -46,4 +47,5 @@ __all__ = [
     "bootstrap_target_account",
     "get_default_project_policy",
     "load_network_values",
+    "force_manage_policy_attach",
 ]

--- a/seedfarmer/commands/_deployment_commands.py
+++ b/seedfarmer/commands/_deployment_commands.py
@@ -237,6 +237,15 @@ def _execute_destroy(
         region=target_region,
     )
 
+    commands.force_manage_policy_attach(
+        deployment_name=cast(str, deployment_manifest.name),
+        group_name=group_name,
+        module_name=module_manifest.name,
+        account_id=target_account_id,
+        region=target_region,
+        module_role_name=module_role_name,
+    )
+
     resp = commands.destroy_module(
         deployment_name=cast(str, deployment_manifest.name),
         deployment_partition=cast(str, deployment_manifest._partition),

--- a/test/unit-test/test_commands_deployment.py
+++ b/test/unit-test/test_commands_deployment.py
@@ -284,6 +284,7 @@ def test_execute_destroy(session_manager, mocker):
     )
     mocker.patch("seedfarmer.commands._deployment_commands.commands.destroy_module", return_value=mod_resp)
     mocker.patch("seedfarmer.commands._deployment_commands.commands.destroy_module_stack", return_value=None)
+    mocker.patch("seedfarmer.commands._deployment_commands.commands.force_manage_policy_attach", return_value=None)
     module_manifest.deploy_spec = DeploySpec(**mock_deployspec.dummy_deployspec)
     dc._execute_destroy(
         group_name=group.name,


### PR DESCRIPTION
*Issue #, if available:*
#457 

*Description of changes:*
Forcing the attachment of the managed project policy to module roles when deleting modules - to combat legacy issues.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
