### PR TITLE
uopdating docs - typo in manifest name definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ### Changes
 
 ### Fixes
+- Docs - manifest name description (seed-farmer/docs/source/manifests.md) needed correction
 
 ## v3.0.1 (2023-11-10)
 

--- a/docs/source/manifests.md
+++ b/docs/source/manifests.md
@@ -244,9 +244,10 @@ dataFiles:
   - filePath: test1.txt
   - filePath: git::https://github.com/awslabs/idf-modules.git//modules/storage/buckets/deployspec.yaml?ref=release/1.0.0&depth=1
 ```
-- **name** - the name of the group
+- **name** - the name of the module
+  - this name must be unique in the group of the deployment
 - **path** - this element supports two sources of code:
-  - the relative path to the module code in the project
+  - the relative path to the module code in the project if deploying code from the local filesystem
   - a public Git Repository, leveraging the Terraform semantic as denoted [HERE](https://www.terraform.io/language/modules/sources#generic-git-repository)
 - **targetAccount** - the alias of the account from the [deployment manifest mappings](deployment_manifest)
 - **targetRegion** - the name of the region to deploy to - this overrides any mappings


### PR DESCRIPTION
*Issue #, if available:*
Reported in ADDF that the `name` field in the module manifest was incorrect in the description...

*Description of changes:*
Updating the description of name under the module manifest in docs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
