### PR TITLE
adding ability to check the runtime of seedfarmer in in seedfarmer.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 
 ### Changes
 - updating pydantic support from 1.X.X to 2.5.3
+- adding seedfarmer verions check support with `seedfarmer.yaml`
 
 ### Fixes
 - update `manifests/examples/` to point to an updated release branch

--- a/docs/source/project_development.md
+++ b/docs/source/project_development.md
@@ -27,13 +27,15 @@ It is important to have the ```seedfarmer.yaml``` at the root of your project.  
 project: <your project name>
 description: <your project description>
 projectPolicyPath: <relativepath/policyname.yaml>
+seedfarmer_version: <minimum required seedfermer version>
 ```
 - **project** (REQUIRED) - this is the name of the project that all deployments will reference 
 - **description** (OPTIONAL) - this is the description of the project
 - **projectPolicyPath** (OPTIONAL) - this allows advanced users change the project policy that has the basic minimim permissions seedfarmer needs
   - it consists of a path relative to the project root and MUST be a valid relative path
   - to synth the existing project policy, run `seedfarmer projectpolicy synth` 
-
+- **seedfarmer_version** (OPTIONAL) - this specifies what is the minimum allowable version of `seed-farmer` the project supports
+  - if this value is set AND the runtime version of seedfarmer is greater, `seed-farmer` will exit immediately
 
 
 (project_initalization)=

--- a/seedfarmer/__init__.py
+++ b/seedfarmer/__init__.py
@@ -22,6 +22,7 @@ import pkg_resources
 import yaml
 from aws_codeseeder import LOGGER, codeseeder
 from aws_codeseeder.codeseeder import CodeSeederConfig
+from packaging.version import parse
 
 import seedfarmer.errors
 from seedfarmer.__metadata__ import __description__, __license__, __title__
@@ -90,6 +91,13 @@ class Config(object):
                 if self._project_spec.project_policy_path
                 else os.path.join(CLI_ROOT, DEFAULT_PROJECT_POLICY_PATH)
             )
+            if self._project_spec.seedfarmer_version:
+                if parse(__version__) < parse(str(self._project_spec.seedfarmer_version)):
+                    msg = (
+                        f"The seedfarmer.yaml specified a minimum version: "
+                        f"{self._project_spec.seedfarmer_version} but you are using {__version__}"
+                    )
+                    raise seedfarmer.errors.SeedFarmerException(msg)
 
         @codeseeder.configure(self._project_spec.project.lower(), deploy_if_not_exists=True)
         def configure(configuration: CodeSeederConfig) -> None:

--- a/seedfarmer/models/_project_spec.py
+++ b/seedfarmer/models/_project_spec.py
@@ -12,7 +12,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-from typing import Optional
+from typing import Optional, Union
 
 from seedfarmer.models._base import CamelModel
 
@@ -27,3 +27,4 @@ class ProjectSpec(CamelModel):
     project: str
     description: Optional[str] = None
     project_policy_path: Optional[str] = None
+    seedfarmer_version: Optional[Union[int, str]] = None


### PR DESCRIPTION
*Issue #, if available:*
#463 

*Description of changes:*
Add support in seedfarmer.yaml to specify the minimum seedfarmer version supported by the project, logic sill exit the build if this minimum is not met (when populated).  It is NOT a required field.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
