### PR TITLE
refactor: Move coverage and mypy settings into the `pyproject.toml` file

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,9 +21,9 @@ jobs:
       run:
         working-directory: .
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Requirements

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9,3.10.13]
+        python-version: [3.7, 3.9, 3.10, 3.11]
     defaults:
       run:
         working-directory: .
@@ -33,7 +33,7 @@ jobs:
           pip install -r requirements-dev.txt
           pip install -e .
       - name: Mypy Check
-        run: mypy --ignore-missing-imports ./seedfarmer
+        run: mypy ./seedfarmer
       - name: Flake8 Check
         run: flake8 ./seedfarmer
       - name: Black Check

--- a/.gitignore
+++ b/.gitignore
@@ -386,3 +386,5 @@ _build/
 
 # Pytest Setup
 /module/
+seedfarmer.yaml
+tmp-metadata

--- a/.gitignore
+++ b/.gitignore
@@ -386,5 +386,3 @@ _build/
 
 # Pytest Setup
 /module/
-seedfarmer.yaml
-tmp-metadata

--- a/coverage.ini
+++ b/coverage.ini
@@ -1,3 +1,0 @@
-[run]
-omit =
-    test/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 120
-target-version = ["py36", "py37", "py38"]
+target-version = ["py37", "py38", "py39"]
 exclude = '''
 /(
     \.eggs
@@ -29,6 +29,13 @@ line_length = 120
 src_paths = ["seedfarmer"]
 py_version = 36
 skip_gitignore = false
+
+[tool.mypy]
+python_version = "3.7"
+strict = true
+ignore_missing_imports = true
+disallow_untyped_decorators = false
+exclude = "codeseeder.out/|examples/|modules/|test/|seedfarmer.gitmodules/"
 
 [tool.pytest.ini_options]
 markers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,15 @@ markers = [
     "commands_bootstrap: marks all `commands_bootstrap` tests",
 ]
 log_cli_level = "INFO"
-addopts = "-v --cov=. --cov-report=term --cov-report=html --cov-config=coverage.ini --cov-fail-under=80"
+addopts = "-v --cov=. --cov-report=term --cov-report=html"
 pythonpath = [
   "."
 ]
+
+[tool.pytest.coverage.run]
+omit = [
+  "test/*"
+]
+
+[tool.coverage.report]
+fail_under = 80.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 120
-target-version = ["py37", "py38", "py39"]
+target-version = ["py37", "py38", "py39","py310","py311"]
 exclude = '''
 /(
     \.eggs
@@ -27,7 +27,7 @@ use_parentheses = true
 ensure_newline_before_comments = true
 line_length = 120
 src_paths = ["seedfarmer"]
-py_version = 36
+py_version = 37
 skip_gitignore = false
 
 [tool.mypy]

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,11 +18,3 @@ exclude =
     codeseeder.out,
     bundle,
     seedfarmer.gitmodules
-
-[mypy]
-python_version = 3.7
-strict = True
-ignore_missing_imports = True
-allow_untyped_decorators = True
-exclude =
-  codeseeder.out/|examples/|modules/|test/|seedfarmer.gitmodules/


### PR DESCRIPTION
## Description of changes
Currently, a lot of our static checker and unit test settings are scatter across multiple configuration files, which makes it confusing to figure out where each config value was coming from.

This PR is moving mypy and coverage settings into `pyproject.toml`. Sadly, flake8 doesn't support the TOML file so it has to remain in `setup.cfg` for now.

In a future PR, we can move our dependencies into the `pyproject.toml` file as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
