### PR TITLE
detect large manifests and reduce size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
   - Users can override this with the `--update-seedkit` flag in case AWS CodeSeeder has updated the SeedKit
 
 ### Fixes
+- adding in workaround for manifests whose char length is greater than SSM limit of 8192 k
 
 
 ## v3.1.2 (2024-01-24)

--- a/seedfarmer/utils.py
+++ b/seedfarmer/utils.py
@@ -15,7 +15,7 @@
 import hashlib
 import logging
 import os
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 import humps
 import yaml
@@ -183,3 +183,12 @@ def load_dotenv_files(root_path: str, env_files: List[str]) -> None:
         loaded_values.update(dotenv_values(dotenv_path, verbose=True))
 
     _logger.debug("Loaded environment variables: %s", loaded_values)
+
+
+def remove_nulls(payload: Dict[str, Any]) -> Dict[str, Any]:
+    if isinstance(payload, dict):
+        return {k: remove_nulls(v) for k, v in payload.items() if v is not None}
+    elif isinstance(payload, list):
+        return [remove_nulls(v) for v in payload]
+    else:
+        return payload

--- a/test/unit-test/test_mgmt_module_info.py
+++ b/test/unit-test/test_mgmt_module_info.py
@@ -246,7 +246,8 @@ def test_write_module_manifest(aws_credentials, session, mocker):
     import seedfarmer.mgmt.module_info as mi
 
     mocker.patch("seedfarmer.mgmt.module_info.ssm.put_parameter", return_value=True)
-    mi.write_module_manifest(deployment="myapp", group="test", module="mymodule", data={"Hey", "Yo"}, session=session)
+    payload = {"Hey", "Yo"}
+    mi.write_module_manifest(deployment="myapp", group="test", module="mymodule", data=dict.fromkeys(payload, 0), session=session)
 
 
 @pytest.mark.mgmt


### PR DESCRIPTION
*Issue #, if available:*
#499 
*Description of changes:*
Module Manifests can grow large when parameters increase, and pydantic serializes None values.  SSM has a limit of 8192 k (chars) .  We are stripping the None values out prior to writing to SSM IF the size is greater than 8192  as a stop-gap.

We realize that this is not a permanent fix.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
