### PR TITLE
adding support for thread names logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ### New
 
 ### Changes
+- renaming the threads spawned for deploy / destroy to indicate the module being worked on
 
 ### Fixes
 


### PR DESCRIPTION
*Issue #, if available:*
#504 
*Description of changes:*
Rename the threads spawned for deployment to logging is easier to decipher.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
