### PR TITLE
adding schema support 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ## Unreleased
 
 ### New
+- support to generate schema for manifests from CLI (`seedfarmer list schema`)
 
 ### Changes
 - renaming the threads spawned for deploy / destroy to indicate the module being worked on
@@ -15,7 +16,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 - adding info for destroy and list deployments when no deployments found
 
 ### Fixes
-
+- Add schema validation step checking that either `value` or `value_from` is present for each parameter
 
 ## v3.2.2 (2024-02-27)
 
@@ -55,8 +56,6 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 
 ### Fixes
 - adding in workaround for manifests whose char length is greater than SSM limit of 8192 k
-
-- Add schema validation step checking that either `value` or `value_from` is present for each parameter
 
 
 ## v3.1.2 (2024-01-24)

--- a/docs/source/cli_commands.rst
+++ b/docs/source/cli_commands.rst
@@ -69,7 +69,9 @@ Summary of Commands
 .. click:: seedfarmer.cli_groups._list_group:list_build_env_params 
     :prog: seedfarmer list buildparams 
     :nested: full  
-
+.. click:: seedfarmer.cli_groups._list_group:list_manifest_schema
+    :prog: seedfarmer list schema 
+    :nested: full  
 ..
   bootstrap commands
   

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ markers = [
     "mgmt_deployment_utils: marks all `mgmt_deployment_utils` tests",
     "mgmt_deployment_utils_filter: marks all `mgmt_deployment_utils_filter` tests",
     "mgmt_metadata_support: marks all `mgmt_metadata_support` tests",
+    "mgmt_build_info: marks all `mgmt_build_info` tests",
     "service: marks all `services` tests",
     "projectpolicy: marks all `projectpolicy` tests",
     "metadata: marks all `metadata` tests",

--- a/seedfarmer/cli_groups/_list_group.py
+++ b/seedfarmer/cli_groups/_list_group.py
@@ -766,3 +766,13 @@ def list_build_env_params(
                 sys.stdout.write("\n")
         else:
             _error_messaging(deployment, group, module)
+
+
+@list.command(
+    name="schema",
+    help="""Generate the schema that SeedFarmer uses for manifest objects.
+             This will return a formatted string of the schema that can
+             be piped to a file. """,
+)
+def list_manifest_schema() -> None:
+    print(json.dumps(bi.get_manifest_schema(), indent=2))

--- a/seedfarmer/mgmt/build_info.py
+++ b/seedfarmer/mgmt/build_info.py
@@ -18,6 +18,7 @@ from typing import Any, Dict, List, Optional
 
 from boto3 import Session
 
+from seedfarmer.models.manifests._deployment_manifest import DeploymentManifest
 from seedfarmer.services import _codebuild as codebuild
 
 _logger: logging.Logger = logging.getLogger(__name__)
@@ -37,3 +38,7 @@ def get_build_env_params(build_ids: List[str], session: Optional[Session] = None
     )
     list_of_envs = [{entry_dict["name"]: entry_dict["value"]} for entry_dict in env_params] if env_params else None
     return dict(ChainMap(*list_of_envs)) if list_of_envs else None
+
+
+def get_manifest_schema() -> Dict[str, Any]:
+    return DeploymentManifest.model_json_schema()

--- a/test/unit-test/mock_data/mock_build_info.py
+++ b/test/unit-test/mock_data/mock_build_info.py
@@ -1,0 +1,273 @@
+codebuild_response = {
+    "builds": [
+        {
+            "id": "codeseeder-idf:7f53415b-f47d-4e5e-860f-93d7f440aa30",
+            "arn": "arn:aws:codebuild:us-east-1:123456789012:build/codeseeder-idf:7f53415b-f47d-4e5e-860f-93d7f440aa30",
+            "buildNumber": 7,
+            "startTime": "2024-03-13T20:24:02.191000-04:00",
+            "endTime": "2024-03-13T20:26:33.189000-04:00",
+            "currentPhase": "COMPLETED",
+            "buildStatus": "SUCCEEDED",
+            "projectName": "codeseeder-idf",
+            "phases": [
+                {
+                    "phaseType": "SUBMITTED",
+                    "phaseStatus": "SUCCEEDED",
+                    "startTime": "2024-03-13T20:24:02.191000-04:00",
+                    "endTime": "2024-03-13T20:24:02.360000-04:00",
+                    "durationInSeconds": 0
+                },
+                {
+                    "phaseType": "QUEUED",
+                    "phaseStatus": "SUCCEEDED",
+                    "startTime": "2024-03-13T20:24:02.360000-04:00",
+                    "endTime": "2024-03-13T20:24:03.331000-04:00",
+                    "durationInSeconds": 0
+                },
+                {
+                    "phaseType": "PROVISIONING",
+                    "phaseStatus": "SUCCEEDED",
+                    "startTime": "2024-03-13T20:24:03.331000-04:00",
+                    "endTime": "2024-03-13T20:24:11.188000-04:00",
+                    "durationInSeconds": 7,
+                    "contexts": [
+                        {
+                            "statusCode": "",
+                            "message": ""
+                        }
+                    ]
+                },
+                {
+                    "phaseType": "DOWNLOAD_SOURCE",
+                    "phaseStatus": "SUCCEEDED",
+                    "startTime": "2024-03-13T20:24:11.188000-04:00",
+                    "endTime": "2024-03-13T20:24:17.501000-04:00",
+                    "durationInSeconds": 6,
+                    "contexts": [
+                        {
+                            "statusCode": "",
+                            "message": ""
+                        }
+                    ]
+                },
+                {
+                    "phaseType": "INSTALL",
+                    "phaseStatus": "SUCCEEDED",
+                    "startTime": "2024-03-13T20:24:17.501000-04:00",
+                    "endTime": "2024-03-13T20:26:16.074000-04:00",
+                    "durationInSeconds": 118,
+                    "contexts": [
+                        {
+                            "statusCode": "",
+                            "message": ""
+                        }
+                    ]
+                },
+                {
+                    "phaseType": "PRE_BUILD",
+                    "phaseStatus": "SUCCEEDED",
+                    "startTime": "2024-03-13T20:26:16.074000-04:00",
+                    "endTime": "2024-03-13T20:26:16.246000-04:00",
+                    "durationInSeconds": 0,
+                    "contexts": [
+                        {
+                            "statusCode": "",
+                            "message": ""
+                        }
+                    ]
+                },
+                {
+                    "phaseType": "BUILD",
+                    "phaseStatus": "SUCCEEDED",
+                    "startTime": "2024-03-13T20:26:16.246000-04:00",
+                    "endTime": "2024-03-13T20:26:31.774000-04:00",
+                    "durationInSeconds": 15,
+                    "contexts": [
+                        {
+                            "statusCode": "",
+                            "message": ""
+                        }
+                    ]
+                },
+                {
+                    "phaseType": "POST_BUILD",
+                    "phaseStatus": "SUCCEEDED",
+                    "startTime": "2024-03-13T20:26:31.774000-04:00",
+                    "endTime": "2024-03-13T20:26:32.877000-04:00",
+                    "durationInSeconds": 1,
+                    "contexts": [
+                        {
+                            "statusCode": "",
+                            "message": ""
+                        }
+                    ]
+                },
+                {
+                    "phaseType": "UPLOAD_ARTIFACTS",
+                    "phaseStatus": "SUCCEEDED",
+                    "startTime": "2024-03-13T20:26:32.877000-04:00",
+                    "endTime": "2024-03-13T20:26:32.931000-04:00",
+                    "durationInSeconds": 0,
+                    "contexts": [
+                        {
+                            "statusCode": "",
+                            "message": ""
+                        }
+                    ]
+                },
+                {
+                    "phaseType": "FINALIZING",
+                    "phaseStatus": "SUCCEEDED",
+                    "startTime": "2024-03-13T20:26:32.931000-04:00",
+                    "endTime": "2024-03-13T20:26:33.189000-04:00",
+                    "durationInSeconds": 0,
+                    "contexts": [
+                        {
+                            "statusCode": "",
+                            "message": ""
+                        }
+                    ]
+                },
+                {
+                    "phaseType": "COMPLETED",
+                    "startTime": "2024-03-13T20:26:33.189000-04:00"
+                }
+            ],
+            # "source": {
+            #     "type": "S3",
+            #     "location": "codeseeder-idf-123456789012-jbkeyw/codeseeder/dummy-ecr-ecr-ml-images/bzchpmli/bundle.zip",
+            #     "buildspec": "version: 0.2\nenv:\n    shell: bash\n    variables: {}\n    exported-variables:\n    - SEEDFARMER_MODULE_METADATA\n    - AWS_CODESEEDER_OUTPUT\nphases:\n    install:\n        commands:\n        - mkdir -p /var/scripts/\n        - mv $CODEBUILD_SRC_DIR/bundle/retrieve_docker_creds.py /var/scripts/retrieve_docker_creds.py\n            || "true"\n        - /var/scripts/retrieve_docker_creds.py && echo 'Docker logins successful'\n            || echo 'Docker logins failed'\n        - aws codeartifact login --tool pip --domain aws-codeseeder-idf --repository\n            python-repository\n        - python3 -m venv ~/.venv\n        - . ~/.venv/bin/activate\n        - cd ${CODEBUILD_SRC_DIR}/bundle\n        - pip install aws-codeseeder~=0.11.1\n        - pip install seed-farmer==3.3.0.dev0\n        - cd module/\n        - npm install -g aws-cdk@2.114.1\n        - pip install -r requirements.txt\n        on-failure: ABORT\n        runtime-versions:\n            nodejs: '16'\n            python: '3.10'\n            java: corretto17\n    pre_build:\n        commands:\n        - . ~/.venv/bin/activate\n        - cd ${CODEBUILD_SRC_DIR}/bundle\n        - nohup /usr/local/bin/dockerd --host=unix:///var/run/docker.sock --host=tcp://127.0.0.1:2375\n            --storage-driver=overlay2 &\n        - timeout 15 sh -c \"until docker info; do echo .; sleep 1; done\"\n        - cd module/\n        - export DEPLOYMENT=dummy\n        - export GROUP=ecr\n        - export MODULE=ecr-ml-images\n        on-failure: ABORT\n    build:\n        commands:\n        - . ~/.venv/bin/activate\n        - cd ${CODEBUILD_SRC_DIR}/bundle\n        - codeseeder execute --args-file fn_args.json --debug\n        - if [[ -f /tmp/codeseeder_export.sh ]]; then source /tmp/codeseeder_export.sh;\n            else echo 'No return value to export'; fi\n        - cd module/\n        - cdk destroy --force --app \"python app.py\"\n        on-failure: ABORT\n    post_build:\n        commands:\n        - . ~/.venv/bin/activate\n        - cd ${CODEBUILD_SRC_DIR}/bundle\n        - cd module/\n        - seedfarmer remove moduledata -d dummy -g ecr -m ecr-ml-images\n        on-failure: ABORT\n",
+            #     "insecureSsl": "false"
+            # },
+            "secondarySources": [],
+            "secondarySourceVersions": [],
+            "artifacts": {
+                "location": ""
+            },
+            "cache": {
+                "type": "NO_CACHE"
+            },
+            "environment": {
+                "type": "LINUX_CONTAINER",
+                "image": "aws/codebuild/standard:6.0",
+                "computeType": "BUILD_GENERAL1_SMALL",
+                "environmentVariables": [
+                    {
+                        "name": "AWS_CODESEEDER_DOCKER_SECRET",
+                        "value": "NONE",
+                        "type": "PLAINTEXT"
+                    },
+                    {
+                        "name": "SEEDFARMER_PARAMETER_REPOSITORY_NAME",
+                        "value": "ml-mnist-images",
+                        "type": "PLAINTEXT"
+                    },
+                    {
+                        "name": "AWS_CODESEEDER_NAME",
+                        "value": "idf",
+                        "type": "PLAINTEXT"
+                    },
+                    {
+                        "name": "SEEDFARMER_MODULE_NAME",
+                        "value": "ecr-ecr-ml-images",
+                        "type": "PLAINTEXT"
+                    },
+                    {
+                        "name": "SEEDFARMER_VERSION",
+                        "value": "3.3.0.dev0",
+                        "type": "PLAINTEXT"
+                    },
+                    {
+                        "name": "SEEDFARMER_MODULE_METADATA",
+                        "value": "{\"AwsCodeSeederDeployed\": \"0.11.1\", \"EcrRepositoryArn\": \"arn:aws:ecr:us-east-1:123456789012:repository/ml-mnist-images\", \"EcrRepositoryName\": \"ml-mnist-images\", \"LifecycleMaxImages\": \"10\", \"SeedFarmerDeployed\": \"3.3.0.dev0\"}",
+                        "type": "PLAINTEXT"
+                    },
+                    {
+                        "name": "SEEDFARMER_DEPLOYMENT_NAME",
+                        "value": "dummy",
+                        "type": "PLAINTEXT"
+                    },
+                    {
+                        "name": "AWS_PARTITION",
+                        "value": "aws",
+                        "type": "PLAINTEXT"
+                    },
+                    {
+                        "name": "AWS_CODESEEDER_VERSION",
+                        "value": "0.11.1",
+                        "type": "PLAINTEXT"
+                    },
+                    {
+                        "name": "AWS_ACCOUNT_ID",
+                        "value": "123456789012",
+                        "type": "PLAINTEXT"
+                    },
+                    {
+                        "name": "SEEDFARMER_PROJECT_NAME",
+                        "value": "idf",
+                        "type": "PLAINTEXT"
+                    },
+                    {
+                        "name": "SEEDFARMER_HASH",
+                        "value": "074ff5b4",
+                        "type": "PLAINTEXT"
+                    },
+                    {
+                        "name": "SEEDFARMER_PARAMETER_LIFECYCLE_MAX_IMAGE_COUNT",
+                        "value": "10",
+                        "type": "PLAINTEXT"
+                    },
+                    {
+                        "name": "SEEDFARMER_PARAMETER_IMAGE_TAG_MUTABILITY",
+                        "value": "MUTABLE",
+                        "type": "PLAINTEXT"
+                    }
+                ],
+                "privilegedMode": "true",
+                "imagePullCredentialsType": "CODEBUILD"
+            },
+            "serviceRole": "arn:aws:iam::123456789012:role/idf-dummy-ecr-ecr-ml-images-074ff5b4",
+            "logs": {
+                "groupName": "/aws/codebuild/codeseeder-idf",
+                "streamName": "codeseeder-bzchpmli/7f53415b-f47d-4e5e-860f-93d7f440aa30",
+                "deepLink": "https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/$252Faws$252Fcodebuild$252Fcodeseeder-idf/log-events/codeseeder-bzchpmli$252F7f53415b-f47d-4e5e-860f-93d7f440aa30",
+                "cloudWatchLogsArn": "arn:aws:logs:us-east-1:123456789012:log-group:/aws/codebuild/codeseeder-idf:log-stream:codeseeder-bzchpmli/7f53415b-f47d-4e5e-860f-93d7f440aa30",
+                "cloudWatchLogs": {
+                    "status": "ENABLED",
+                    "groupName": "/aws/codebuild/codeseeder-idf",
+                    "streamName": "codeseeder-bzchpmli"
+                },
+                "s3Logs": {
+                    "status": "DISABLED",
+                    "encryptionDisabled": "false"
+                }
+            },
+            "timeoutInMinutes": 120,
+            "queuedTimeoutInMinutes": 480,
+            "buildComplete": "true",
+            "initiator": "seedfarmer-idf-deployment-role/deployment_role",
+            "exportedEnvironmentVariables": [
+                {
+                    "name": "AWS_CODESEEDER_OUTPUT",
+                    "value": "\"{\\\"aws_region\\\": \\\"us-east-1\\\", \\\"aws_account_id\\\": \\\"123456789012\\\", \\\"aws_partition\\\": \\\"aws\\\", \\\"codebuild_build_id\\\": \\\"codeseeder-idf:7f53415b-f47d-4e5e-860f-93d7f440aa30\\\", \\\"codebuild_log_path\\\": \\\"codeseeder-bzchpmli/7f53415b-f47d-4e5e-860f-93d7f440aa30\\\"}\""
+                },
+                {
+                    "name": "SEEDFARMER_MODULE_METADATA",
+                    "value": "{\"AwsCodeSeederDeployed\": \"0.11.1\", \"EcrRepositoryArn\": \"arn:aws:ecr:us-east-1:123456789012:repository/ml-mnist-images\", \"EcrRepositoryName\": \"ml-mnist-images\", \"LifecycleMaxImages\": \"10\", \"SeedFarmerDeployed\": \"3.3.0.dev0\"}"
+                }
+            ]
+        }
+    ],
+    "buildsNotFound": [],
+    "ResponseMetadata": {
+        "RequestId": "11701f62-9639-4fe3-82d9-dcbc38ac41af",
+        "HTTPStatusCode": 200,
+        "HTTPHeaders": {
+            "x-amzn-requestid": "11701f62-9639-4fe3-82d9-dcbc38ac41af",
+            "content-type": "application/x-amz-json-1.1",
+            "content-length": "7670",
+            "date": "Fri, 29 Mar 2024 14:38:06 GMT"
+        },
+        "RetryAttempts": 0
+    }
+}

--- a/test/unit-test/test_mgmt_build_info.py
+++ b/test/unit-test/test_mgmt_build_info.py
@@ -1,0 +1,80 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License").
+#    You may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+import logging
+import os
+
+import boto3
+import mock_data.mock_build_info as mock_build_info
+import mock_data.mock_deployment_manifest_huge as mock_deployment_manifest_huge
+import mock_data.mock_manifests as mock_manifests
+import mock_data.mock_module_info_huge as mock_module_info_huge
+import pytest
+from moto import mock_sts
+
+import seedfarmer.errors
+import seedfarmer.mgmt.build_info as bi
+from seedfarmer.models.manifests import DeploymentManifest
+from seedfarmer.services._service_utils import boto3_client
+from seedfarmer.services.session_manager import SessionManager
+
+_logger: logging.Logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="function")
+def aws_credentials():
+    """Mocked AWS Credentials for moto."""
+    os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+    os.environ["AWS_SECURITY_TOKEN"] = "testing"
+    os.environ["AWS_SESSION_TOKEN"] = "testing"
+    os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+    os.environ["MOTO_ACCOUNT_ID"] = "123456789012"
+
+
+@pytest.fixture(scope="function")
+def sts_client(aws_credentials):
+    with mock_sts():
+        yield boto3_client(service_name="sts", session=None)
+
+
+@pytest.fixture(scope="function")
+def session_manager(sts_client):
+    SessionManager._instances = {}
+    SessionManager().get_or_create(
+        project_name="test",
+        region_name="us-east-1",
+        toolchain_region="us-east-1",
+        enable_reaper=False,
+    )
+
+
+@pytest.mark.mgmt
+@pytest.mark.mgmt_build_info
+def test_get_build_params(mocker):
+    mocker.patch("seedfarmer.mgmt.build_info.codebuild.get_build_data", return_value=mock_build_info.codebuild_response)
+    build_id = 'codeseeder-idf:7f53415b-f47d-4e5e-860f-93d7f440aa30'
+    env_params = bi.get_build_env_params(build_ids=[build_id]) #[Dict[str, Any]
+    assert "SEEDFARMER_HASH" in env_params.keys()
+    assert "SEEDFARMER_PROJECT_NAME" in env_params.keys()
+
+
+
+@pytest.mark.mgmt
+@pytest.mark.mgmt_build_info
+def test_validate_group_parameters():
+    bi.get_manifest_schema()
+
+
+


### PR DESCRIPTION
*Issue #, if available:*
#383 
*Description of changes:*
Adding the CLI support to generate the schema that SF uses for manifests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
