### PR TITLE
adding commit hash support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 
 ### New
 - support to generate schema for manifests from CLI (`seedfarmer list schema`)
+- added commithash persistence support for modules sourced from git
+  - recorded in module manifest (`commit_hash`)
+  - recorded in module metadata as `SeedFarmerModuleCommitHash` and can be fetched
 
 ### Changes
 - renaming the threads spawned for deploy / destroy to indicate the module being worked on
@@ -14,6 +17,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 - complete support to delete the seedkit on `seedfarmer destroy` command
 - adding verbose messaging to session manager and hints to reconcile session issues
 - adding info for destroy and list deployments when no deployments found
+- refactored git support logic to separate python file
 
 ### Fixes
 - Add schema validation step checking that either `value` or `value_from` is present for each parameter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ markers = [
     "mgmt_deployment_utils_filter: marks all `mgmt_deployment_utils_filter` tests",
     "mgmt_metadata_support: marks all `mgmt_metadata_support` tests",
     "mgmt_build_info: marks all `mgmt_build_info` tests",
+    "mgmt_git_support: marks all `mgmt_git_support` tests",
     "service: marks all `services` tests",
     "projectpolicy: marks all `projectpolicy` tests",
     "metadata: marks all `metadata` tests",

--- a/seedfarmer/commands/_module_commands.py
+++ b/seedfarmer/commands/_module_commands.py
@@ -125,6 +125,11 @@ def deploy_module(
     metadata_env_variable = _param("MODULE_METADATA", use_project_prefix)
     sf_version__add = [f"seedfarmer metadata add -k AwsCodeSeederDeployed -v { aws_codeseeder.__version__} || true"]
     cs_version_add = [f"seedfarmer metadata add -k SeedFarmerDeployed -v {seedfarmer.__version__} || true"]
+    githash_add = (
+        [f"seedfarmer metadata add -k SeedFarmerModuleCommitHash -v {module_manifest.commit_hash} || true"]
+        if module_manifest.commit_hash
+        else []
+    )
     metadata_put = [
         f"if [[ -f {metadata_env_variable} ]]; then export {metadata_env_variable}=$(cat {metadata_env_variable}); fi",
         (
@@ -164,6 +169,7 @@ def deploy_module(
             + md5_put
             + sf_version__add
             + cs_version_add
+            + githash_add
             + metadata_put,
             extra_env_vars=env_vars,
             codebuild_compute_type=module_manifest.deploy_spec.build_type,

--- a/seedfarmer/messages.py
+++ b/seedfarmer/messages.py
@@ -8,7 +8,7 @@ checklist = """  Be sure to check:
 
 
 def no_deployment_found(deployment_name: Optional[str] = None) -> str:
-    msg = "We found no deployments with yout active session."
+    msg = "We found no deployments with your active session."
     if deployment_name:
         msg = f"We found no deployments named {deployment_name} with your active session."
 

--- a/seedfarmer/mgmt/git_support.py
+++ b/seedfarmer/mgmt/git_support.py
@@ -1,0 +1,85 @@
+import logging
+import os
+from typing import Optional, Tuple
+from urllib.parse import parse_qs
+
+import git
+from git import Repo
+
+from seedfarmer import config
+
+_logger: logging.Logger = logging.getLogger(__name__)
+
+
+def get_commit_hash(repo: git.Repo) -> Optional[str]:
+    try:
+        return str(repo.head.object.hexsha)
+    except Exception:
+        _logger.warn("Could not get a commit hash, ignoring")
+        return None
+
+
+def clone_module_repo(git_path: str) -> Tuple[str, str, Optional[str]]:
+    """Clone a git repo and return directory it is cloned into
+
+    Rather than reinventing the wheel, we implement the Generic Git Repository functionality introduced by
+    Terraform. Full documentation on the Git URL definition can be found at:
+    https://www.terraform.io/language/modules/sources#generic-git-repository
+
+    Parameters
+    ----------
+    git_path : str
+        The Git URL specified in the Module Manifest. Full example:
+        https://example.com/network.git//modules/vpc?ref=v1.2.0&depth=1
+
+    Returns
+    -------
+    Tuple[str,str]
+        Returns a tuple that contains (in 0rder):
+        - the full path of the seedfarmer.gitmodules where the repo was cloned to
+        - the relative path to seedfarmer.gitmodules of the module code
+        - the commit hash associated wtih this code
+    """
+    # gitpython library has started blocking non https and ssh protocols by default
+    # codecommit is not _actually_ unsafe
+    allow_unsafe_protocols = git_path.startswith("git::codecommit")
+
+    git_path = git_path.replace("git::", "")
+    ref: Optional[str] = None
+    depth: Optional[int] = None
+    module_directory = ""
+
+    if "?" in git_path:
+        git_path, query = git_path.split("?")
+        query_params = parse_qs(query)
+        ref = query_params.get("ref", [None])[0]  # type: ignore
+        if "depth" in query_params and query_params["depth"][0].isnumeric():
+            depth = int(query_params["depth"][0])
+
+    if ".git//" in git_path:
+        git_path, module_directory = git_path.split(".git//")
+
+    repo_directory = git_path.replace("https://", "").replace("git@", "").replace("/", "_").replace(":", "_")
+
+    working_dir = os.path.join(
+        config.OPS_ROOT, "seedfarmer.gitmodules", f"{repo_directory}_{ref.replace('/', '_')}" if ref else repo_directory
+    )
+    os.makedirs(working_dir, exist_ok=True)
+    repo = None
+    if not os.listdir(working_dir):
+        if ref is not None:
+            _logger.debug("Creating local repo and setting remote: %s into %s: ref=%s ", git_path, working_dir, ref)
+            repo = Repo.init(working_dir)
+            git.Remote.create(repo, "origin", git_path, allow_unsafe_protocols)
+            repo.remotes["origin"].pull(ref, allow_unsafe_protocols=allow_unsafe_protocols)
+        else:
+            _logger.debug("Cloning %s into %s: ref=%s depth=%s", git_path, working_dir, ref, depth)
+            repo = Repo.clone_from(
+                git_path, working_dir, branch=ref, depth=depth, allow_unsafe_protocols=allow_unsafe_protocols
+            )
+    else:
+        _logger.debug("Pulling existing repo %s at %s: ref=%s", git_path, working_dir, ref)
+        repo = Repo(working_dir)
+        repo.remotes["origin"].pull(ref, allow_unsafe_protocols=allow_unsafe_protocols)
+    commit_hash = get_commit_hash(repo)
+    return (working_dir, module_directory, commit_hash)

--- a/seedfarmer/models/manifests/_module_manifest.py
+++ b/seedfarmer/models/manifests/_module_manifest.py
@@ -15,6 +15,7 @@
 from typing import Any, List, Optional
 
 from pydantic import PrivateAttr, model_validator
+from pydantic.json_schema import SkipJsonSchema
 
 from seedfarmer.errors import InvalidManifestError
 from seedfarmer.models._base import CamelModel, ValueFromRef
@@ -53,6 +54,7 @@ class ModuleParameter(ValueFromRef):
 
 class DataFile(CamelModel):
     file_path: str
+    commit_hash: SkipJsonSchema[Optional[str]] = None
     _local_file_path: Optional[str] = PrivateAttr(default=None)
     _bundle_path: Optional[str] = PrivateAttr(default=None)
 
@@ -93,6 +95,7 @@ class ModuleManifest(CamelModel):
     target_region: Optional[str] = None
     codebuild_image: Optional[str] = None
     data_files: Optional[List[DataFile]] = None
+    commit_hash: SkipJsonSchema[Optional[str]] = None
     _target_account_id: Optional[str] = PrivateAttr(default=None)
     _local_path: Optional[str] = PrivateAttr(default=None)
 

--- a/test/unit-test/test_commands_deployment.py
+++ b/test/unit-test/test_commands_deployment.py
@@ -125,52 +125,8 @@ def test_destroy_not_found(session_manager, mocker):
 
 @pytest.mark.commands
 @pytest.mark.commands_deployment
-def test_clone_module_repo_branch(mocker):
-    git_path_test = "git::https://github.com/awslabs/idf-modules.git//modules/network/basic-cdk/?ref=release/1.1.0"
-    git_path_test_redo = "git::https://github.com/awslabs/idf-modules.git//modules/dummy/blank?ref=release/1.1.0"
-
-    return_dir = dc._clone_module_repo(git_path=git_path_test)
-    # Make sure the pull works on an existing repo
-    return_dir = dc._clone_module_repo(git_path=git_path_test_redo)
-
-
-@pytest.mark.commands
-@pytest.mark.commands_deployment
-def test_clone_module_repo_tag(mocker):
-    git_path_test = "git::https://github.com/awslabs/idf-modules.git//modules/network/basic-cdk/?ref=v1.1.0"
-    git_path_test_redo = "git::https://github.com/awslabs/idf-modules.git//modules/dummy/blank?depth=1"
-
-    return_dir = dc._clone_module_repo(git_path=git_path_test)
-    # Make sure the pull works on an existing repo
-    return_dir = dc._clone_module_repo(git_path=git_path_test_redo)
-
-
-@pytest.mark.commands
-@pytest.mark.commands_deployment
-def test_clone_module_repo_commit(mocker):
-    git_path_test = "git::https://github.com/awslabs/idf-modules.git//modules/replication/dockerimage-replication?ref=a190c5c93e84c34c9af070eb59c2e7b65f973afd"
-    git_path_test_redo = "git::https://github.com/awslabs/idf-modules.git//modules/replication/dockerimage-replication?ref=a190c5c93e84c34c9af070eb59c2e7b65f973afd"
-
-    return_dir = dc._clone_module_repo(git_path=git_path_test)
-    # Make sure the pull works on an existing repo
-    return_dir = dc._clone_module_repo(git_path=git_path_test_redo)
-
-
-@pytest.mark.commands
-@pytest.mark.commands_deployment
-def test_clone_module_repo_main(mocker):
-    git_path_test = "git::https://github.com/awslabs/idf-modules.git//modules/dummy/blank?depth=1"
-    git_path_test_redo = "git::https://github.com/awslabs/idf-modules.git//modules/network/basic-cdk?depth=1"
-
-    return_dir = dc._clone_module_repo(git_path=git_path_test)
-    # Make sure the pull works on an existing repo
-    return_dir = dc._clone_module_repo(git_path=git_path_test_redo)
-
-
-@pytest.mark.commands
-@pytest.mark.commands_deployment
 def test_process_data_files(mocker):
-    mocker.patch("seedfarmer.commands._deployment_commands._clone_module_repo", return_value=("git", "path"))
+    mocker.patch("seedfarmer.commands._deployment_commands.sf_git.clone_module_repo", return_value=("git", "path", "sdfasfas"))
     mocker.patch("seedfarmer.commands._deployment_commands.du.validate_data_files", return_value=[])
     git_path_test = "git::https://github.com/awslabs/idf-modules.git//modules/dummy/blank?ref=release/1.0.0&depth=1"
     datafile_list = []
@@ -183,7 +139,7 @@ def test_process_data_files(mocker):
 @pytest.mark.commands
 @pytest.mark.commands_deployment
 def test_process_data_files_error(mocker):
-    mocker.patch("seedfarmer.commands._deployment_commands._clone_module_repo", return_value=("git", "path"))
+    mocker.patch("seedfarmer.commands._deployment_commands.sf_git.clone_module_repo", return_value=("git", "path", "sdfasfas"))
     mocker.patch("seedfarmer.commands._deployment_commands.du.validate_data_files", return_value=["hey"])
     git_path_test = "git::https://github.com/awslabs/idf-modules.git//modules/dummy/blank?ref=release/1.0.0&depth=1"
     datafile_list = []

--- a/test/unit-test/test_mgmt_build_info.py
+++ b/test/unit-test/test_mgmt_build_info.py
@@ -15,17 +15,11 @@
 import logging
 import os
 
-import boto3
 import mock_data.mock_build_info as mock_build_info
-import mock_data.mock_deployment_manifest_huge as mock_deployment_manifest_huge
-import mock_data.mock_manifests as mock_manifests
-import mock_data.mock_module_info_huge as mock_module_info_huge
 import pytest
 from moto import mock_sts
 
-import seedfarmer.errors
 import seedfarmer.mgmt.build_info as bi
-from seedfarmer.models.manifests import DeploymentManifest
 from seedfarmer.services._service_utils import boto3_client
 from seedfarmer.services.session_manager import SessionManager
 

--- a/test/unit-test/test_mgmt_git_support.py
+++ b/test/unit-test/test_mgmt_git_support.py
@@ -1,0 +1,103 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License").
+#    You may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+import logging
+import os
+
+
+import pytest
+from moto import mock_sts
+
+import seedfarmer.mgmt.build_info as bi
+from seedfarmer.services._service_utils import boto3_client
+from seedfarmer.services.session_manager import SessionManager
+import seedfarmer.mgmt.git_support as sf_git
+
+_logger: logging.Logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="function")
+def aws_credentials():
+    """Mocked AWS Credentials for moto."""
+    os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+    os.environ["AWS_SECURITY_TOKEN"] = "testing"
+    os.environ["AWS_SESSION_TOKEN"] = "testing"
+    os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+    os.environ["MOTO_ACCOUNT_ID"] = "123456789012"
+
+
+@pytest.fixture(scope="function")
+def sts_client(aws_credentials):
+    with mock_sts():
+        yield boto3_client(service_name="sts", session=None)
+
+
+@pytest.fixture(scope="function")
+def session_manager(sts_client):
+    SessionManager._instances = {}
+    SessionManager().get_or_create(
+        project_name="test",
+        region_name="us-east-1",
+        toolchain_region="us-east-1",
+        enable_reaper=False,
+    )
+
+
+
+@pytest.mark.mgmt
+@pytest.mark.mgmt_git_support
+def test_clone_module_repo_branch(mocker):
+    git_path_test = "git::https://github.com/awslabs/idf-modules.git//modules/network/basic-cdk/?ref=release/1.1.0"
+    git_path_test_redo = "git::https://github.com/awslabs/idf-modules.git//modules/dummy/blank?ref=release/1.1.0"
+
+    sf_git_dir, module_path, commit_hash = sf_git.clone_module_repo(git_path=git_path_test)
+    # Make sure the pull works on an existing repo
+    sf_git_dir, module_path, commit_hash = sf_git.clone_module_repo(git_path=git_path_test_redo)
+
+
+@pytest.mark.mgmt
+@pytest.mark.mgmt_git_support
+def test_clone_module_repo_tag(mocker):
+    git_path_test = "git::https://github.com/awslabs/idf-modules.git//modules/network/basic-cdk/?ref=v1.1.0"
+    git_path_test_redo = "git::https://github.com/awslabs/idf-modules.git//modules/dummy/blank?depth=1"
+
+    sf_git_dir, module_path, commit_hash = sf_git.clone_module_repo(git_path=git_path_test)
+    # Make sure the pull works on an existing repo
+    sf_git_dir, module_path, commit_hash = sf_git.clone_module_repo(git_path=git_path_test_redo)
+
+
+@pytest.mark.mgmt
+@pytest.mark.mgmt_git_support
+def test_clone_module_repo_commit(mocker):
+    git_path_test = "git::https://github.com/awslabs/idf-modules.git//modules/replication/dockerimage-replication?ref=a190c5c93e84c34c9af070eb59c2e7b65f973afd"
+    git_path_test_redo = "git::https://github.com/awslabs/idf-modules.git//modules/replication/dockerimage-replication?ref=a190c5c93e84c34c9af070eb59c2e7b65f973afd"
+
+    sf_git_dir, module_path, commit_hash = sf_git.clone_module_repo(git_path=git_path_test)
+    # Make sure the pull works on an existing repo
+    sf_git_dir, module_path, commit_hash = sf_git.clone_module_repo(git_path=git_path_test_redo)
+
+
+@pytest.mark.mgmt
+@pytest.mark.mgmt_git_support
+def test_clone_module_repo_main(mocker):
+    git_path_test = "git::https://github.com/awslabs/idf-modules.git//modules/dummy/blank?depth=1"
+    git_path_test_redo = "git::https://github.com/awslabs/idf-modules.git//modules/network/basic-cdk?depth=1"
+
+    sf_git_dir, module_path, commit_hash = sf_git.clone_module_repo(git_path=git_path_test)
+    # Make sure the pull works on an existing repo
+    sf_git_dir, module_path, commit_hash = sf_git.clone_module_repo(git_path=git_path_test_redo)
+
+
+


### PR DESCRIPTION
*Issue #, if available:*
#529 

*Description of changes:*
- Refactored git support code 9moved to separate py file to reduce bloat)
- added `commit_hash' field to manifest to store in SSM (not accessible via schema definition)
- added `SeedFarmerModuleCommitHash` metadata output to allow fetching as part of metadata for reference

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
