### PR TITLE
adding git error messaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 - adding verbose messaging to session manager and hints to reconcile session issues
 - adding info for destroy and list deployments when no deployments found
 - refactored git support logic to separate python file
+- added verbose messaging related to git issues
 
 ### Fixes
 - Add schema validation step checking that either `value` or `value_from` is present for each parameter

--- a/seedfarmer/messages.py
+++ b/seedfarmer/messages.py
@@ -1,15 +1,23 @@
 from typing import Optional
 
-checklist = """  Be sure to check:
-        1. The session that you are executing the CLI from matches the ACCOUNT and REGION
-           where your toolchain is configured
-        2. The session has permissions to access the proper toolchain role
-        """
-
 
 def no_deployment_found(deployment_name: Optional[str] = None) -> str:
     msg = "We found no deployments with your active session."
     if deployment_name:
         msg = f"We found no deployments named {deployment_name} with your active session."
 
+    checklist = """  Be sure to check:
+            1. The session that you are executing the CLI from matches the ACCOUNT and REGION
+            where your toolchain is configured
+            2. The session has permissions to access the proper toolchain role
+            """
+
     return msg + checklist
+
+
+def git_error_support() -> str:
+    return """
+    1. Make sure your path to the repo is correct and valid (check your module manifests!)
+    2. The credentials used to call SeedFarmer have access to the repo
+    3. The credentials used to call SeedFarmer have not expired
+    """


### PR DESCRIPTION
*Issue #, if available:*
#528 

*Description of changes:*
Adding verbose messaging when git calls fail in SF.  Status code responses mapped to a descriptive reason were not readily available, so that is being messaged back to the caller with hints how to reconcile. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
