### PR TITLE
feat: Add strict validation for unknown values in manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ### New
 
 ### Changes
+- enforce strict validation for unknown values in manifests
 
 ### Fixes
 

--- a/docs/source/project_development.md
+++ b/docs/source/project_development.md
@@ -28,6 +28,7 @@ project: <your project name>
 description: <your project description>
 projectPolicyPath: <relativepath/policyname.yaml>
 seedfarmer_version: <minimum required seedfermer version>
+manifestValidationFailOnUnknownFields: <whether to fail on unknown fields in the manifest>
 ```
 - **project** (REQUIRED) - this is the name of the project that all deployments will reference 
 - **description** (OPTIONAL) - this is the description of the project
@@ -36,6 +37,8 @@ seedfarmer_version: <minimum required seedfermer version>
   - to synth the existing project policy, run `seedfarmer projectpolicy synth` 
 - **seedfarmer_version** (OPTIONAL) - this specifies what is the minimum allowable version of `seed-farmer` the project supports
   - if this value is set AND the runtime version of seedfarmer is greater, `seed-farmer` will exit immediately
+- **manifestValidationFailOnUnknownFields** (OPTIONAL) - this specifies whether SeedFarmer will fail if it finds unknown fields ion the manifest
+  - possible values are `true` or `false`, where `false` is the default
 
 
 (project_initalization)=

--- a/seedfarmer/__init__.py
+++ b/seedfarmer/__init__.py
@@ -137,5 +137,11 @@ class Config(object):
             self._load_config_data()
         return str(cast(ProjectSpec, self._project_spec).project_policy_path)
 
+    @property
+    def MANIFEST_VALIDATION_FAIL_ON_UNKNOWN_FIELDS(self) -> bool:
+        if self._project_spec is None:
+            self._load_config_data()
+        return cast(ProjectSpec, self._project_spec).manifest_validation_fail_on_unknown_fields
+
 
 config = Config()

--- a/seedfarmer/models/_base.py
+++ b/seedfarmer/models/_base.py
@@ -25,7 +25,7 @@ def to_camel(string: str) -> str:
 class CamelModel(BaseModel):
     # TODO[pydantic]: The following keys were removed: `underscore_attrs_are_private`.
     # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-config for more information.
-    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True, extra="forbid")
 
 
 class ModuleRef(CamelModel):

--- a/seedfarmer/models/_deploy_spec.py
+++ b/seedfarmer/models/_deploy_spec.py
@@ -42,10 +42,10 @@ class BuildPhases(CamelModel):
     install, pre_build,  build, post_build
     """
 
-    install: BuildPhase = BuildPhase()
-    pre_build: BuildPhase = BuildPhase()
-    build: BuildPhase = BuildPhase()
-    post_build: BuildPhase = BuildPhase()
+    install: BuildPhase = BuildPhase.model_construct()
+    pre_build: BuildPhase = BuildPhase.model_construct()
+    build: BuildPhase = BuildPhase.model_construct()
+    post_build: BuildPhase = BuildPhase.model_construct()
 
 
 class ExecutionType(CamelModel):
@@ -55,7 +55,7 @@ class ExecutionType(CamelModel):
     object of the DeploySpec
     """
 
-    phases: BuildPhases = BuildPhases()
+    phases: BuildPhases = BuildPhases.model_construct()
 
 
 class DeploySpec(CamelModel):

--- a/seedfarmer/models/_project_spec.py
+++ b/seedfarmer/models/_project_spec.py
@@ -14,6 +14,9 @@
 
 from typing import Optional, Union
 
+from pydantic import model_validator
+
+from seedfarmer.errors.seedfarmer_errors import InvalidManifestError
 from seedfarmer.models._base import CamelModel
 
 
@@ -28,3 +31,11 @@ class ProjectSpec(CamelModel):
     description: Optional[str] = None
     project_policy_path: Optional[str] = None
     seedfarmer_version: Optional[Union[int, str]] = None
+    manifest_validation_fail_on_unknown_fields: bool = False
+
+    @model_validator(mode="after")
+    def check_for_extra_fields(self) -> "ProjectSpec":
+        if self.manifest_validation_fail_on_unknown_fields and self.model_extra:
+            raise InvalidManifestError(f"The following keys are not allowed: {self.model_extra}")
+
+        return self

--- a/test/unit-test/mock_data/seedfarmer.yaml
+++ b/test/unit-test/mock_data/seedfarmer.yaml
@@ -1,2 +1,3 @@
 project: myapp
 description: unit testing
+manifest_validation_fail_on_unknown_fields: true

--- a/test/unit-test/mock_data/seedfarmer.yaml
+++ b/test/unit-test/mock_data/seedfarmer.yaml
@@ -1,3 +1,3 @@
 project: myapp
 description: unit testing
-manifest_validation_fail_on_unknown_fields: true
+manifestValidationFailOnUnknownFields: true

--- a/test/unit-test/test_mgmt_deploy_utils.py
+++ b/test/unit-test/test_mgmt_deploy_utils.py
@@ -205,7 +205,7 @@ def test_generate_deployed_manifest_already_deployed(mocker, session_manager):
     mocker.patch("seedfarmer.mgmt.deploy_utils.populate_module_info_index", return_value=None)
     mocker.patch(
         "seedfarmer.mgmt.deploy_utils._populate_group_modules_from_index",
-        return_value=mock_manifests.deployment_manifest["groups"],
+        side_effect=[group["modules"] for group in mock_manifests.deployment_manifest["groups"]],
     )
     du.generate_deployed_manifest(deployment_name="myapp", skip_deploy_spec=True, ignore_deployed=True)
 
@@ -220,7 +220,7 @@ def test_generate_deployed_manifest(mocker, session_manager):
     mocker.patch("seedfarmer.mgmt.deploy_utils.populate_module_info_index", return_value=None)
     mocker.patch(
         "seedfarmer.mgmt.deploy_utils._populate_group_modules_from_index",
-        return_value=mock_manifests.deployment_manifest["groups"],
+        side_effect=[group["modules"] for group in mock_manifests.deployment_manifest["groups"]],
     )
     du.generate_deployed_manifest(deployment_name="myapp", skip_deploy_spec=True, ignore_deployed=False)
 

--- a/test/unit-test/test_models.py
+++ b/test/unit-test/test_models.py
@@ -16,6 +16,7 @@ import logging
 import os
 from copy import deepcopy
 
+from unittest import mock
 import pytest
 import yaml
 
@@ -413,6 +414,57 @@ parameters:
         module = ModuleManifest(**module_yaml)
         manifest.groups[0].modules = [module]
         manifest.validate_and_set_module_defaults()
+
+
+@pytest.mark.models
+@pytest.mark.models_module_manifest
+def test_module_manifest_with_unknown_value():
+    manifest = DeploymentManifest(**deployment_yaml)
+
+    module_yaml = yaml.safe_load(
+        """
+name: test-module-1
+path: modules/test-module
+targetAccount: primary
+targetRegion: us-west-2
+parameters:
+  - name: param1
+    value: value1
+    non_existent_value: fail_me
+"""
+    )
+
+    with pytest.raises(InvalidManifestError):
+        module = ModuleManifest(**module_yaml)
+        manifest.groups[0].modules = [module]
+        manifest.validate_and_set_module_defaults()
+
+
+@pytest.mark.models
+@pytest.mark.models_module_manifest
+def test_module_manifest_with_unknown_value_config_no_fail():
+    manifest = DeploymentManifest(**deployment_yaml)
+
+    module_yaml = yaml.safe_load(
+        """
+name: test-module-1
+path: modules/test-module
+targetAccount: primary
+targetRegion: us-west-2
+parameters:
+  - name: param1
+    value: value1
+    non_existent_value: fail_me
+"""
+    )
+
+    with mock.patch("seedfarmer.config") as config:
+        config.MANIFEST_VALIDATION_FAIL_ON_UNKNOWN_FIELDS = False
+
+        module = ModuleManifest(**module_yaml)
+        manifest.groups[0].modules = [module]
+        manifest.validate_and_set_module_defaults()
+
 
 
 @pytest.mark.models

--- a/test/unit-test/test_models.py
+++ b/test/unit-test/test_models.py
@@ -428,11 +428,6 @@ targetAccount: primary
 targetRegion: us-west-2
 parameters:
   - name: param1
-    # missing value_from
-    moduleMetadata:
-      group: test-group
-      name: test-module-1
-      key: param-key
 """
     )
 
@@ -508,5 +503,4 @@ def test_deployresponses():
         aws_region="us-east-1",
         codebuild_build_id="codebuild:12345",
         codebuild_log_path="/somepath",
-        status="success",
     )


### PR DESCRIPTION
*Issue #, if available:* #560

*Description of changes:* We currently have `pydantic` set up so that it ignores any value it finds in the manifest files that it didn't expect. This PR is changing that behavior so that such values throw validation errors. As a consequence of this change, a few of our unit tests needed to be fixed, as they were using invalid manifests, which previously weren't detected as invalid.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
