### PR TITLE
adding universal env replace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ## Unreleased
 
 ### New
+- adding universal environment replace in manifests (ref: `${SOMEKEY}`)
 
 ### Changes
 

--- a/seedfarmer/models/manifests/_deployment_manifest.py
+++ b/seedfarmer/models/manifests/_deployment_manifest.py
@@ -177,6 +177,9 @@ class DeploymentManifest(CamelModel):
     _partition: Optional[str] = PrivateAttr(default="aws")
 
     def __init__(self, **kwargs: Any) -> None:
+        from seedfarmer.utils import batch_replace_env
+
+        kwargs = batch_replace_env(payload=kwargs)
         super().__init__(**kwargs)
 
         if self.name is None and self.name_generator is None:

--- a/seedfarmer/models/manifests/_module_manifest.py
+++ b/seedfarmer/models/manifests/_module_manifest.py
@@ -101,8 +101,12 @@ class ModuleManifest(CamelModel):
     _target_account_id: Optional[str] = PrivateAttr(default=None)
     _local_path: Optional[str] = PrivateAttr(default=None)
 
-    def __init__(self, **data: Any) -> None:
-        super().__init__(**data)
+    def __init__(self, **kwargs: Any) -> None:
+
+        from seedfarmer.utils import batch_replace_env
+
+        kwargs = batch_replace_env(payload=kwargs)
+        super().__init__(**kwargs)
         self._local_path = self.path
 
     def set_target_account_id(self, account_id: str) -> None:

--- a/test/unit-test/mock_data/mock_deployment_manifest_huge.py
+++ b/test/unit-test/mock_data/mock_deployment_manifest_huge.py
@@ -252,3 +252,47 @@ deployment_manifest = {
         }
     ],
 }
+
+
+deployment_manifest_batch_replace = {
+    "name": "${DEP_NAME}",
+    "toolchain_region": "${REGION}",
+    "groups": [
+        {
+            "name": "optionals",
+            "path": "manifests/mlops/optional-modules.yaml",
+            "modules": [
+                {
+                    "name": "networking",
+                    "path": "modules/optionals/networking/",
+                    "parameters": [{"name": "internet-accessible", "value": True}],
+                    "target_account": "primary",
+                    "target_region": "us-east-1",
+                },
+                {
+                    "name": "datalake-buckets",
+                    "path": "modules/optionals/datalake-buckets",
+                    "parameters": [{"name": "encryption-type", "value": "SSE"}],
+                    "target_account": "primary",
+                    "target_region": "us-east-1",
+                },
+            ],
+        }
+    ],
+    "target_account_mappings": [
+        {
+            "alias": "primary",
+            "account_id": "${ACCOUNT_ID}",
+            "default": True,
+            "parameters_global": {"dockerCredentialsSecret": "aws-addf-docker-credentials"},
+            "region_mappings": [
+                {
+                    "region": "us-east-1",
+                    "default": True,
+                    "parameters_regional": {},
+                }
+            ],
+        }
+    ],
+}
+

--- a/test/unit-test/test_mgmt_deploy_utils.py
+++ b/test/unit-test/test_mgmt_deploy_utils.py
@@ -204,9 +204,9 @@ def test_generate_deployed_manifest_already_deployed(mocker, session_manager):
     )
     mocker.patch("seedfarmer.mgmt.deploy_utils.populate_module_info_index", return_value=None)
     mocker.patch(
-        "seedfarmer.mgmt.deploy_utils._populate_group_modules_from_index",
-        return_value=mock_manifests.deployment_manifest["groups"],
-    )
+    "seedfarmer.mgmt.deploy_utils._populate_group_modules_from_index",
+        side_effect=[group["modules"] for group in mock_manifests.deployment_manifest["groups"]],
+    ) 
     du.generate_deployed_manifest(deployment_name="myapp", skip_deploy_spec=True, ignore_deployed=True)
 
 
@@ -219,9 +219,9 @@ def test_generate_deployed_manifest(mocker, session_manager):
     )
     mocker.patch("seedfarmer.mgmt.deploy_utils.populate_module_info_index", return_value=None)
     mocker.patch(
-        "seedfarmer.mgmt.deploy_utils._populate_group_modules_from_index",
-        return_value=mock_manifests.deployment_manifest["groups"],
-    )
+    "seedfarmer.mgmt.deploy_utils._populate_group_modules_from_index",
+        side_effect=[group["modules"] for group in mock_manifests.deployment_manifest["groups"]],
+    )    
     du.generate_deployed_manifest(deployment_name="myapp", skip_deploy_spec=True, ignore_deployed=False)
 
 

--- a/test/unit-test/test_utils.py
+++ b/test/unit-test/test_utils.py
@@ -13,11 +13,20 @@
 #    limitations under the License.
 
 import logging
-from copy import deepcopy
-
+import mock_data.mock_deployment_manifest_huge as mock
+import os 
 import pytest
+import seedfarmer.errors
+import seedfarmer.utils as utils
 
 _logger: logging.Logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="function")
+def env_params():
+    os.environ["DEP_NAME"] = "testing"
+    os.environ["REGION"] = "us-east-1"
+    os.environ["ACCOUNT_ID"] = "123456789012"
 
 
 @pytest.mark.utils_test
@@ -37,3 +46,13 @@ def test_utils():
     pascal_case = utils.upper_snake_case("Pascal_Case")
     assert pascal_case == "PASCAL_CASE"
     # session_hash = utils.generate_session_hash()
+
+
+@pytest.mark.utils_test
+def test_validate_module_dependencies(env_params):
+    replaced = utils.batch_replace_env(mock.deployment_manifest_batch_replace)
+    assert replaced["name"] == "testing"
+    assert replaced["toolchain_region"] == "us-east-1"
+    assert replaced["target_account_mappings"][0]["account_id"] == '123456789012'
+    
+


### PR DESCRIPTION
*Issue #, if available:*
#562 
#538
*Description of changes:*
Adding the ability to dynamically replace environment parameters when defined in the deployment manifest or the module manifest and wrapped in `${ }`.   This EXCLUDES the deployspec modulestack, and you cannot dynamically replace any named key in the manifest (this should be obvious).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
