### PR TITLE
correcting resolution of account for parameter lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 - enforce strict validation for unknown values in manifests
 
 ### Fixes
-
+- resolving parameter values via regional / global mappings needs to use account id, not alias
 
 ## v3.4.0 (2024-04-19)
 

--- a/seedfarmer/commands/_parameter_commands.py
+++ b/seedfarmer/commands/_parameter_commands.py
@@ -98,7 +98,7 @@ def load_parameter_values(
                 )
             elif parameter.value_from.parameter_value:
                 p_value = deployment_manifest.get_parameter_value(
-                    parameter=parameter.value_from.parameter_value, account_alias=target_account, region=target_region
+                    parameter=parameter.value_from.parameter_value, account_id=target_account, region=target_region
                 )
                 if p_value is not None:
                     p_value = str(p_value) if isinstance(p_value, str) else json.dumps(p_value)

--- a/test/unit-test/test_commands_parameters.py
+++ b/test/unit-test/test_commands_parameters.py
@@ -197,7 +197,7 @@ def test_load_parameter_values(session_manager, mocker):
         deployment_name="mlops",
         deployment_manifest=dep,
         parameters=dep.groups[1].modules[0].parameters,
-        target_account="primary",
+        target_account="123456789012",
         target_region="us-east-1",
     )
     names = []


### PR DESCRIPTION
*Issue #, if available:*
#562 
*Description of changes:*
When looking up the parameter value from mappings, the alias was used when it really should be the account id.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
