### PR TITLE
feat: support env parameter ENDPOINT_URL to helps locate the sp…

### DIFF
--- a/seedfarmer/services/_service_utils.py
+++ b/seedfarmer/services/_service_utils.py
@@ -25,6 +25,8 @@ import seedfarmer.errors
 
 _logger: logging.Logger = logging.getLogger(__name__)
 
+_endpoint_url =  os.getenv('ENDPOINT_URL')
+
 
 def setup_proxies() -> Dict[str, Optional[str]]:
     proxies = {}
@@ -69,15 +71,23 @@ def boto3_client(
     aws_session_token: Optional[str] = None,
 ) -> boto3.client:
     if aws_access_key_id and aws_secret_access_key and aws_session_token:
-        return create_new_session_with_creds(
-            aws_access_key_id, aws_secret_access_key, aws_session_token, region_name
-        ).client(service_name=service_name, use_ssl=True, config=get_botocore_config())
+        if not _endpoint_url:
+            return create_new_session_with_creds(
+                aws_access_key_id, aws_secret_access_key, aws_session_token, region_name
+            ).client(service_name=service_name, use_ssl=True, config=get_botocore_config())
+        else:
+            return create_new_session_with_creds(
+                aws_access_key_id, aws_secret_access_key, aws_session_token, region_name
+            ).client(service_name=service_name, use_ssl=True, config=get_botocore_config(), endpoint_url=_endpoint_url)
     elif not session:
         return create_new_session(region_name, profile).client(
             service_name=service_name, use_ssl=True, config=get_botocore_config()
         )
     else:
-        return session.client(service_name=service_name, use_ssl=True, config=get_botocore_config())
+        if not _endpoint_url:
+            return session.client(service_name=service_name, use_ssl=True, config=get_botocore_config())
+        else:
+            return session.client(service_name=service_name, use_ssl=True, config=get_botocore_config(), endpoint_url=_endpoint_url)
 
 
 def boto3_resource(

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     keywords=["aws", "cdk"],
     python_requires=">=3.8,<3.12",
     install_requires=[
-        "aws-codeseeder~=0.13.0",
+        "aws-codeseeder>=0.13.0",
         "cookiecutter~=2.1.0",
         "pyhumps~=3.5.0",
         "pydantic~=2.5.3",


### PR DESCRIPTION
…ecified aws service entrypoint

- #579

*Description of changes:*
When integrating with localstack, it reports that the security token included in the request is invalid. The reason is that the profile was not successfully passed when creating the session somewhere. The easiest way to modify it is to specify the endpoint through environment variables when creating boto3 client.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
