### PR TITLE
updating error messaging on failed manifest paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ### New
 
 ### Changes
-
+- adding local path of manifests that fail to load to the actual final string printed
+  - this is already being done, but moving closer to last line of output
 ### Fixes
 
 ## v3.5.0 (2024-05-09)

--- a/seedfarmer/commands/_deployment_commands.py
+++ b/seedfarmer/commands/_deployment_commands.py
@@ -661,11 +661,15 @@ def apply(
             try:
                 with open(os.path.join(config.OPS_ROOT, module_group.path)) as manifest_file:
                     module_group.modules = [ModuleManifest(**m) for m in yaml.safe_load_all(manifest_file)]
+            except FileNotFoundError as fe:
+                _logger.error(fe)
+                _logger.error(f"Cannot parse a file at {os.path.join(config.OPS_ROOT, module_group.path)}")
+                _logger.error("Verify (in deployment manifest) that relative path to the module manifest is correct")
+                raise seedfarmer.errors.InvalidPathError(f"Cannot parse manifest file path at {module_group.path}")
             except Exception as e:
                 _logger.error(e)
-                _logger.error(f"Cannot parse a file at {os.path.join(config.OPS_ROOT, module_group.path)}")
                 _logger.error("Verify that elements are filled out and yaml compliant")
-                raise seedfarmer.errors.InvalidPathError("Cannot parse manifest file path")
+                raise seedfarmer.errors.InvalidManifestError("Cannot parse manifest properly")
     deployment_manifest.validate_and_set_module_defaults()
 
     prime_target_accounts(

--- a/seedfarmer/mgmt/module_info.py
+++ b/seedfarmer/mgmt/module_info.py
@@ -833,5 +833,5 @@ def get_modulestack_path(module_path: str) -> Any:
 def get_deployspec_path(module_path: str) -> str:
     p = os.path.join(config.OPS_ROOT, module_path, "deployspec.yaml")
     if not os.path.exists(p):
-        raise seedfarmer.errors.InvalidPathError("No deployspec.yaml file found in module directory: %s", p)
+        raise seedfarmer.errors.InvalidPathError(f"No deployspec.yaml file found in module directory: {p}")
     return os.path.join(config.OPS_ROOT, module_path, "deployspec.yaml")


### PR DESCRIPTION
*Issue #, if available:*
#581 
*Description of changes:*
Adding messaging to the error output of path where manifest cannot be found.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
