### PR TITLE
fix how deployed manifest is stored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ### Changes
 
 ### Fixes
+- correcting how SeedFarmer stores deployed manifests of previously deployed modules in SSM
+
 
 ## v4.0.0 (2024-06-03)
 

--- a/seedfarmer/utils.py
+++ b/seedfarmer/utils.py
@@ -61,10 +61,10 @@ def upper_snake_case(value: str) -> str:
     str
         the string standardized
     """
-    if humps.is_camelcase(value):
-        return humps.decamelize(value).upper()
-    elif humps.is_pascalcase(value):
-        return humps.depascalize(value).upper()
+    if humps.is_camelcase(value):  # type: ignore[attr-defined]
+        return humps.decamelize(value).upper()  # type: ignore[attr-defined]
+    elif humps.is_pascalcase(value):  # type: ignore[attr-defined]
+        return humps.depascalize(value).upper()  # type: ignore[attr-defined]
     else:
         return value.replace("-", "_").upper()
 

--- a/seedfarmer/utils.py
+++ b/seedfarmer/utils.py
@@ -61,10 +61,10 @@ def upper_snake_case(value: str) -> str:
     str
         the string standardized
     """
-    if humps.is_camelcase(value):  # type: ignore[attr-defined]
-        return humps.decamelize(value).upper()  # type: ignore[attr-defined]
-    elif humps.is_pascalcase(value):  # type: ignore[attr-defined]
-        return humps.depascalize(value).upper()  # type: ignore[attr-defined]
+    if humps.is_camelcase(value):
+        return humps.decamelize(value).upper()
+    elif humps.is_pascalcase(value):
+        return humps.depascalize(value).upper()
     else:
         return value.replace("-", "_").upper()
 


### PR DESCRIPTION
*Issue #, if available:*
#615 

*Description of changes:*
The manifest being stored is the WIP, not the overall manifest.  This issue was introduced in the 3.4.x release and am correcting it here.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
