### PR TITLE
fix: Validation script error and outdated docs

### DIFF
--- a/docs/source/module_best_practices.md
+++ b/docs/source/module_best_practices.md
@@ -28,7 +28,7 @@ Feel free to copy these scripts into your own project for application to your mo
 
 ### fix.sh
 The `fix.sh` script will apply standardization libraries to your code based on the language.
-* `python` code uses [isort](https://pycqa.github.io/isort/) and [black](https://black.readthedocs.io/en/stable/)
+* `python` code uses [ruff](https://docs.astral.sh/ruff/)
 * `typescript` code uses [prettier](https://www.npmjs.com/package/prettier)
 
 To run, from commandline pass in the language and relative path to yur module:
@@ -40,7 +40,7 @@ To run, from commandline pass in the language and relative path to yur module:
 
 ### validate.sh
 The `validate.sh` script will apply check libraries to your code based on the language.
-* `python` code uses [isort](https://pycqa.github.io/isort/), [black](https://black.readthedocs.io/en/stable/), [mypy](https://mypy.readthedocs.io/en/stable/), [flake8](https://flake8.pycqa.org/en/latest/)
+* `python` code uses [ruff](https://docs.astral.sh/ruff/) and [mypy](https://mypy.readthedocs.io/en/stable/)
 * `typescript` code uses [prettier](https://www.npmjs.com/package/prettier)
 * `ALL CODE` - [cfn-lint](https://github.com/aws-cloudformation/cfn-lint) is applied to all `modulestack.yaml` files
 

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -52,8 +52,8 @@ echo "Validating: $(cd "$(dirname "$VALIDATE_PATH")"; pwd)/$(basename "$VALIDATE
 echo "Validating Formatting"
 if [[ $LANGUAGE == "python" ]]; then
     echo "Running ruff"
-    ruff format ${FIX_PATH}
-    ruff check --fix ${FIX_PATH}
+    ruff format --check ${VALIDATE_PATH}
+    ruff check --fix ${VALIDATE_PATH}
 elif [[ $LANGUAGE == "typescript" ]]; then
     echo "Checking prettier"
     npx prettier -c ${VALIDATE_PATH}
@@ -66,7 +66,6 @@ if [[ $SKIP_STATIC_CHECKS == "false" ]]; then
     echo "Validating Static Checks"
     if [[ $LANGUAGE == "python" ]]; then
         echo "Checking mypy"
-        #flake8 ${VALIDATE_PATH}
         mypy --ignore-missing-imports ${VALIDATE_PATH}
     else
         echo "ERROR Language: ${LANGUAGE}"


### PR DESCRIPTION
*Description of changes:*
- fixing error in the `validate.sh` script
- updating docs to reflect the correct linters and formatters for Python

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
