### PR TITLE
fixing the destroy if a path is missing but bundle exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,10 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ### Changes
 
 ### Fixes
+- when a bundle is available on destroy, ignore the path entirely
 
-## v4.0.2 (2024-07-08
-)
+## v4.0.2 (2024-07-08)
+
 ### New
 
 ### Changes

--- a/seedfarmer/commands/_module_commands.py
+++ b/seedfarmer/commands/_module_commands.py
@@ -283,6 +283,7 @@ def destroy_module(mdo: ModuleDeployObject) -> ModuleDeploymentResponse:
     npm_mirror = module_manifest.npm_mirror if module_manifest.npm_mirror is not None else mdo.npm_mirror
     pypi_mirror = module_manifest.pypi_mirror if module_manifest.pypi_mirror is not None else mdo.pypi_mirror
     module_path = os.path.join(config.OPS_ROOT, str(module_manifest.get_local_path()))
+    prebuilt_bundle = _prebuilt_bundle_check(mdo)
     try:
         resp_dict_str, _ = _execute_module_commands(
             deployment_name=str(mdo.deployment_manifest.name),
@@ -291,7 +292,7 @@ def destroy_module(mdo: ModuleDeployObject) -> ModuleDeploymentResponse:
             account_id=account_id,
             region=region,
             metadata_env_variable=metadata_env_variable,
-            extra_dirs={"module": module_path},
+            extra_dirs={"module": module_path} if not prebuilt_bundle else None,
             extra_files=extra_files,
             extra_install_commands=["cd module/"] + _phases.install.commands,
             extra_pre_build_commands=["cd module/"] + _phases.pre_build.commands + export_info,
@@ -304,7 +305,7 @@ def destroy_module(mdo: ModuleDeployObject) -> ModuleDeploymentResponse:
             npm_mirror=npm_mirror,
             pypi_mirror=pypi_mirror,
             runtime_versions=get_runtimes(active_codebuild_image),
-            prebuilt_bundle=_prebuilt_bundle_check(mdo),
+            prebuilt_bundle=prebuilt_bundle,
         )
         resp = ModuleDeploymentResponse(
             deployment=mdo.deployment_manifest.name,


### PR DESCRIPTION
*Issue #, if available:*
#650 
*Description of changes:*
If a bundle is present, use it and do not pass the path to CodeSeeder.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
