### PR TITLE
fix: env replacement only working for first value in string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 
 ### Fixes
 
+- value replacement from environment variables was only working for the first value
+
 
 ## v4.0.3 (2024-07-11)
 

--- a/seedfarmer/utils.py
+++ b/seedfarmer/utils.py
@@ -200,15 +200,14 @@ def batch_replace_env(payload: Dict[str, Any]) -> Dict[str, Any]:
     pattern = r"\${(.*?)}"
 
     def replace_str(value: str) -> str:
-        matches = re.findall(pattern, value)
-        for match in matches:
-            try:
-                value = value.replace("${" + match + "}", os.environ[match.strip()])
-            except KeyError:
-                raise seedfarmer.errors.InvalidManifestError(
-                    f"The environment variable ({match.strip()}) is not available"
-                )
-        return value
+        try:
+            return re.sub(
+                pattern=pattern,
+                repl=lambda m: os.environ[m.group(1).strip()],
+                string=value,
+            )
+        except KeyError as e:
+            raise seedfarmer.errors.InvalidManifestError(f"The environment variable is not available: {e}")
 
     def recurse_list(working_list: List[Any]) -> List[Any]:
         for key, value in enumerate(working_list):

--- a/seedfarmer/utils.py
+++ b/seedfarmer/utils.py
@@ -203,7 +203,7 @@ def batch_replace_env(payload: Dict[str, Any]) -> Dict[str, Any]:
         matches = re.findall(pattern, value)
         for match in matches:
             try:
-                return value.replace("${" + match + "}", os.environ[match.strip()])
+                value = value.replace("${" + match + "}", os.environ[match.strip()])
             except KeyError:
                 raise seedfarmer.errors.InvalidManifestError(
                     f"The environment variable ({match.strip()}) is not available"

--- a/test/unit-test/test_models.py
+++ b/test/unit-test/test_models.py
@@ -573,9 +573,13 @@ parameters:
 """
     )
 
-    with mock.patch.dict(os.environ, {
-        "GIT_URL": "https://github.com/awslabs/module-repo.git",
-        "GIT_BRANCH": "main",
-    }, clear=True):
+    with mock.patch.dict(
+        os.environ,
+        {
+            "GIT_URL": "https://github.com/awslabs/module-repo.git",
+            "GIT_BRANCH": "main",
+        },
+        clear=True,
+    ):
         module = ModuleManifest(**module_yaml)
         assert module.path == "git::https://github.com/awslabs/module-repo.git//modules/module-name/?ref=main"

--- a/test/unit-test/test_models.py
+++ b/test/unit-test/test_models.py
@@ -556,3 +556,26 @@ def test_deployresponses():
         codebuild_build_id="codebuild:12345",
         codebuild_log_path="/somepath",
     )
+
+
+@pytest.mark.models
+@pytest.mark.models_module_manifest
+def test_module_manifest_with_env_var_resolution_in_path():
+    module_yaml = yaml.safe_load(
+        """
+name: test-module-1
+path: "git::${GIT_URL}//modules/module-name/?ref=${GIT_BRANCH}"
+targetAccount: primary
+targetRegion: us-west-2
+parameters:
+  - name: param1
+    value: value1
+"""
+    )
+
+    with mock.patch.dict(os.environ, {
+        "GIT_URL": "https://github.com/awslabs/module-repo.git",
+        "GIT_BRANCH": "main",
+    }, clear=True):
+        module = ModuleManifest(**module_yaml)
+        assert module.path == "git::https://github.com/awslabs/module-repo.git//modules/module-name/?ref=main"


### PR DESCRIPTION
*Issue #, if available:* Fixes #657

*Description of changes:* Value replacement from environment variables was only working for the first value. I fixed this and added a relevant unit test.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
