### PR TITLE
[FEAT #665] New template-branch parameter on init commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 
 ### New
 
+- Added `-b/--template-branch` parameter to `seedfarmer init project` and `seedfarmer init module` so it permits to use multiple branches from a single repository.
+
 ### Changes
 
 ### Fixes

--- a/seedfarmer/cli_groups/_init_group.py
+++ b/seedfarmer/cli_groups/_init_group.py
@@ -22,7 +22,7 @@ from seedfarmer import DEBUG_LOGGING_FORMAT, enable_debug
 _logger: logging.Logger = logging.getLogger(__name__)
 
 
-@click.group(name="init", help="Initiaize a project or module")
+@click.group(name="init", help="Initialize a project or module")
 def init() -> None:
     """Initialize a project or module"""
     pass
@@ -39,8 +39,15 @@ def init() -> None:
     help="The template URL. If not specified, the default template repo is `https://github.com/awslabs/seed-farmer`",
     required=False,
 )
-def init_project(template_url: str) -> None:
-    minit.create_project(template_url=template_url)
+@click.option(
+    "--template-branch",
+    "-b",
+    default="main",
+    help="The Branch on the template repository. If not specified, the default template branch is `main`",
+    required=False,
+)
+def init_project(template_url: str, template_branch: str) -> None:
+    minit.create_project(template_url=template_url, template_branch=template_branch)
 
 
 @init.command(name="module", help="Initialize a new module")
@@ -70,8 +77,17 @@ def init_project(template_url: str) -> None:
     ),
     required=False,
 )
+@click.option(
+    "--template-branch",
+    "-b",
+    default="main",
+    help="The Branch on the template repository. If not specified, the default template branch is `main`",
+    required=False,
+)
 @click.option("--debug/--no-debug", default=False, help="Enable detail logging", show_default=True)
-def init_module(group_name: str, module_name: str, module_type: str, template_url: str, debug: bool) -> None:
+def init_module(
+    group_name: str, module_name: str, module_type: str, template_url: str, template_branch: str, debug: bool
+) -> None:
     if debug:
         enable_debug(format=DEBUG_LOGGING_FORMAT)
     _logger.debug("Initializing module %s", module_name)
@@ -81,4 +97,5 @@ def init_module(group_name: str, module_name: str, module_type: str, template_ur
         module_name=module_name,
         module_type=module_type,
         template_url=template_url,
+        template_branch=template_branch,
     )

--- a/seedfarmer/mgmt/module_init.py
+++ b/seedfarmer/mgmt/module_init.py
@@ -25,7 +25,11 @@ _logger: logging.Logger = logging.getLogger(__name__)
 
 
 def create_module_dir(
-    module_name: str, group_name: Optional[str], module_type: Optional[str], template_url: Optional[str]
+    module_name: str,
+    group_name: Optional[str],
+    module_type: Optional[str],
+    template_url: Optional[str],
+    template_branch: Optional[str] = "main",
 ) -> None:
     """Initializes a directory for a new module.
 
@@ -34,18 +38,21 @@ def create_module_dir(
     Parameters
     ----------
     group_name : Optional[str],
-        Nmae of the group where the module will reside. If group is a nested dir, use `/` as a delimiter
+        Name of the group where the module will reside. If group is a nested dir, use `/` as a delimiter
     module_name : str
         Name of the module. The initialization will include project files pulled from the template_url
     module_type: Optional[str]
         They type of code the module deploys with, adding more boilerplate code
         -- only cdkv2 is supported here
     template_url : Optional[List[str]]
-        A URL, for example a Github repo, that is or contains templating for the initialization
+        A URL, for example a Github repo, that is or contains the template for the for the initialization
+    template_branch : Optional[str]
+        The Branch on the template repository. If not specified, the default template branch is `main`
     """
     module_root = os.path.join(config.OPS_ROOT, "modules")
     module_path = os.path.join(module_root, module_name)
     output_dir = module_root
+    checkout_branch = template_branch
 
     if group_name:
         module_path = os.path.join(module_root, group_name, module_name)
@@ -71,7 +78,7 @@ def create_module_dir(
     )
 
 
-def create_project(template_url: Optional[str]) -> None:
+def create_project(template_url: Optional[str], template_branch: Optional[str] = "main") -> None:
     """Initializes a new project directory.
 
     Creates a new directory that contains files that will aid in setting up a development environment
@@ -80,11 +87,16 @@ def create_project(template_url: Optional[str]) -> None:
     ----------
     project_name : str
         Name of the project. The initialization will include project files pulled from the template_url
+        using the template_branch as reference
     template_url : Optional[List[str]]
-        A URL, for example a Github repo, that is or contains templating for the initialization
+        A URL, for example a Github repo, that is or contains the template for the initialization
+    template_branch : Optional[str]
+        The Branch on the template repository. If not specified, the default template branch is `main`
     """
 
-    checkout_branch = "init-project" if template_url == "https://github.com/awslabs/seed-farmer.git" else None
+    checkout_branch = (
+        "init-project" if template_url == "https://github.com/awslabs/seed-farmer.git" else template_branch
+    )
     _logger.info(" New project will be created in the following dir: %s", os.path.join(config.OPS_ROOT, config.PROJECT))
     cookiecutter(
         template=template_url,

--- a/test/unit-test/test_mgmt.py
+++ b/test/unit-test/test_mgmt.py
@@ -95,6 +95,36 @@ def test_module_init_cdkv2():
 
 
 @pytest.mark.mgmt
+def test_module_init_branch():
+    setup_mod_dir = os.path.join(pathlib.Path(os.getcwd()), "modules")
+
+    if os.path.isdir(setup_mod_dir):
+        shutil.rmtree(setup_mod_dir)
+    import seedfarmer.mgmt.module_init as mi
+
+    mi.create_module_dir(
+        module_name="mytestmodule",
+        group_name="mygroup",
+        module_type="NOT_NEEDED",
+        template_url="https://github.com/briggySmalls/cookiecutter-pypackage.git",
+        template_branch="master",
+    )
+
+    with pytest.raises(Exception) as e:
+        mi.create_module_dir(
+            module_name="mytestmodule",
+            group_name="mygroup",
+            module_type="NOT_NEEDED",
+            template_url="https://github.com/briggySmalls/cookiecutter-pypackage.git",
+            template_branch="master",
+        )
+
+    assert "module mytestmodule already exists" in str(e)
+
+    shutil.rmtree(setup_mod_dir)
+
+
+@pytest.mark.mgmt
 def test_project_init():
     setup_project_dir = os.path.join(pathlib.Path(os.getcwd()), "myapp")
 


### PR DESCRIPTION
*Issue #, if available:*

Feature #665 

*Description of changes:*

- Added `-b/--template-branch` parameter to `seedfarmer init project` and `seedfarmer init module` so it permits to use multiple branches from a single repository.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
