### PR TITLE
fix: adds validation for trusted principal arns in `seedfarmer bootstrap toolchain`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ### Changes
 
 ### Fixes
-
+- Adds validation for trusted principal arns in `seedfarmer bootstrap toolchain`
 
 ## v4.0.4 (2024-07-19)
 

--- a/seedfarmer/cli_groups/_bootstrap_group.py
+++ b/seedfarmer/cli_groups/_bootstrap_group.py
@@ -57,8 +57,7 @@ def bootstrap() -> None:
     help="""ARN of Principals trusted to assume the Toolchain Role.
     This can be used multiple times to create a list.""",
     multiple=True,
-    required=False,
-    default=[],
+    required=True,
 )
 @click.option(
     "--permissions-boundary",

--- a/seedfarmer/commands/_bootstrap_commands.py
+++ b/seedfarmer/commands/_bootstrap_commands.py
@@ -15,6 +15,7 @@
 import json
 import logging
 import os
+import re
 import sys
 from typing import Any, Dict, List, Optional, Tuple, cast
 
@@ -95,6 +96,10 @@ def bootstrap_toolchain_account(
 ) -> Optional[Dict[Any, Any]]:
     if qualifier and not valid_qualifier(qualifier):
         raise seedfarmer.errors.InvalidConfigurationError("The Qualifier must be alphanumeric and 6 characters or less")
+
+    for arn in principal_arns:
+        if not re.match(r"arn:aws:(sts|iam)::(\d{12}|\*):.*$", arn):
+            raise seedfarmer.errors.InvalidConfigurationError(f"Trusted principal: {arn} is not a valid principal arn")
 
     role_stack_name = get_toolchain_role_name(project_name=project_name, qualifier=cast(str, qualifier))
     template = get_toolchain_template(

--- a/test/unit-test/test_commands_bootstrap.py
+++ b/test/unit-test/test_commands_bootstrap.py
@@ -190,6 +190,24 @@ def test_bootstrap_toolchain_account_synth_with_qualifier_fail(mocker, session):
 @pytest.mark.commands
 @pytest.mark.commands_bootstrap
 @pytest.mark.parametrize("session", [boto3.Session()])
+def test_bootstrap_toolchain_account_synth_with_invalid_principal(mocker, session):
+    mocker.patch("seedfarmer.commands._bootstrap_commands.apply_deploy_logic", return_value="")
+
+    with pytest.raises(seedfarmer.errors.InvalidConfigurationError):
+        bc.bootstrap_toolchain_account(
+            project_name="testing",
+            principal_arns=["arn:aws:iam::foobar:role/AdminRole"],
+            permissions_boundary_arn=None,
+            region_name="us-east-1",
+            qualifier="asdfghdd",
+            synthesize=True,
+            as_target=False,
+        )
+
+
+@pytest.mark.commands
+@pytest.mark.commands_bootstrap
+@pytest.mark.parametrize("session", [boto3.Session()])
 def test_bootstrap_toolchain_account_with_policies(mocker, session):
     mocker.patch("seedfarmer.commands._bootstrap_commands.apply_deploy_logic", return_value="")
     mocker.patch("seedfarmer.commands._bootstrap_commands.bootstrap_target_account", return_value="")


### PR DESCRIPTION
Closes #604 

### Changes
- adds validation for trusted principal arns in `seedfarmer bootstrap toolchain`
- adds unit test to check for validation

### Behaviour Changes (Tested Locally)
**Trusted principal now a required arg in `seedfarmer bootstrap toolchain`**
```bash
> seedfarmer bootstrap toolchain --project multi-deploy --region us-west-2 --as-target
Usage: seedfarmer bootstrap toolchain [OPTIONS]
Try 'seedfarmer bootstrap toolchain --help' for help.
```

Error: Missing option '--trusted-principal' / '-t'.
**Invalid principal arn**
```
> seedfarmer bootstrap toolchain --project multi-deploy --trusted-principal foobar --region us-west-2 --as-target
Traceback (most recent call last):
  File "/Users/hansonlu/.pyenv/versions/3.9.13/bin/seedfarmer", line 8, in <module>
    sys.exit(main())
  File "/Users/hansonlu/.pyenv/versions/3.9.13/lib/python3.9/site-packages/seedfarmer/__main__.py", line 296, in main
    cli()
  File "/Users/hansonlu/.pyenv/versions/3.9.13/lib/python3.9/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/Users/hansonlu/.pyenv/versions/3.9.13/lib/python3.9/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/Users/hansonlu/.pyenv/versions/3.9.13/lib/python3.9/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/hansonlu/.pyenv/versions/3.9.13/lib/python3.9/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/hansonlu/.pyenv/versions/3.9.13/lib/python3.9/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/hansonlu/.pyenv/versions/3.9.13/lib/python3.9/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/Users/hansonlu/.pyenv/versions/3.9.13/lib/python3.9/site-packages/seedfarmer/cli_groups/_bootstrap_group.py", line 136, in bootstrap_toolchain
    bootstrap_toolchain_account(
  File "/Users/hansonlu/.pyenv/versions/3.9.13/lib/python3.9/site-packages/seedfarmer/commands/_bootstrap_commands.py", line 102, in bootstrap_toolchain_account
    raise seedfarmer.errors.InvalidConfigurationError(f"Trusted principal: {arn} is not a valid principal arn")
seedfarmer.errors.seedfarmer_errors.InvalidConfigurationError: Trusted principal: foobar is not a valid principal arn
```





By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
