### PR TITLE
fix: Update trusted principal validation to allow additional aws partitions

### DIFF
--- a/seedfarmer/commands/_bootstrap_commands.py
+++ b/seedfarmer/commands/_bootstrap_commands.py
@@ -98,7 +98,7 @@ def bootstrap_toolchain_account(
         raise seedfarmer.errors.InvalidConfigurationError("The Qualifier must be alphanumeric and 6 characters or less")
 
     for arn in principal_arns:
-        if not re.match(r"arn:aws:(sts|iam)::(\d{12}|\*):.*$", arn):
+        if not re.match(r"arn:aws.*:(sts|iam)::(\d{12}|\*):.*$", arn):
             raise seedfarmer.errors.InvalidConfigurationError(f"Trusted principal: {arn} is not a valid principal arn")
 
     role_stack_name = get_toolchain_role_name(project_name=project_name, qualifier=cast(str, qualifier))


### PR DESCRIPTION
### Changes
- Update trusted principal validation to allow additional aws partitions

**I've omitted changelog entry as its redundant with the current unreleased validation fix**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
