### PR TITLE
add Amazon Linux codebuild images to image override with opinionated runtimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ## Unreleased
 
 ### New 
+- add AWS-curated Amazon Linux codebuild images to image override with opinionated runtimes
 
 ### Changes
 

--- a/docs/source/manifests.md
+++ b/docs/source/manifests.md
@@ -391,6 +391,12 @@ There are multiple [build images and available runtimes](https://docs.aws.amazon
 |aws/codebuild/standard:7.0|nodejs:18|
 ||python:3.11|
 ||java:corretto21|
+|aws/codebuild/amazonlinux2-x86_64-standard:4.0|nodejs:16|
+||python:3.9|
+||java:corretto17|
+|aws/codebuild/amazonlinux2-x86_64-standard:5.0|nodejs:18|
+||python:3.11|
+||java:corretto21|
 
 #### Custom Build Images
 If an end user wants to build their own image, it is STRONGLY encouraged to use [this Dockerfile from AWS public repos](https://github.com/awslabs/aws-codeseeder/blob/main/images/code-build-image/Dockerfile) as the base layer.  `seed-farmer` leverages this as the base for its default image ([see HERE](https://github.com/awslabs/aws-codeseeder/blob/main/images/code-build-image/Dockerfile)).  It is up to the module developer to verify all proper libraries are installed and available.

--- a/seedfarmer/commands/_runtimes.py
+++ b/seedfarmer/commands/_runtimes.py
@@ -20,10 +20,14 @@ class CuratedBuildImages:
     class ImageEnums(Enum):
         UBUNTU_STANDARD_6 = "aws/codebuild/standard:6.0"
         UBUNTU_STANDARD_7 = "aws/codebuild/standard:7.0"
+        AL2_STANDARD_4 = "aws/codebuild/amazonlinux2-x86_64-standard:4.0"
+        AL2_STANDARD_5 = "aws/codebuild/amazonlinux2-x86_64-standard:5.0"
 
     class ImageRuntimes(Enum):
         UBUNTU_STANDARD_6 = {"nodejs": "16", "python": "3.10", "java": "corretto17"}
         UBUNTU_STANDARD_7 = {"nodejs": "18", "python": "3.11", "java": "corretto21"}
+        AL2_STANDARD_4 = {"nodejs": "16", "python": "3.9", "java": "corretto17"}
+        AL2_STANDARD_5 = {"nodejs": "18", "python": "3.11", "java": "corretto21"}
 
 
 def get_runtimes(codebuild_image: Optional[str]) -> Optional[Dict[str, str]]:


### PR DESCRIPTION
*Description of changes:*
Add support for AWS CodeBuild-curated, Amazon Linux-based images - extending what has already been done for Ubuntu-based images.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
