### PR TITLE
feat: add parameter to disable env replacement in module params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 
 ### Changes
 
+- Added ability to disable env replacement in module parameters
+
 ### Fixes
 
 ## v5.0.0 (2024-08-16)

--- a/docs/source/manifests.md
+++ b/docs/source/manifests.md
@@ -330,7 +330,7 @@ When using this feature, any change to these file(s) (modifying, add to manifest
 ## Universal Environment Variable Replacement in Manifests
 As of the release of `seed-farmer==3.5.0`, we have added support for dynamic replacement of values with environment variables in manifests.  This does not replace any pre-existing functionality.  This also is limited to only manifests (`deployment_manifest` and `module_manifest`).  Things like the `deployspec` and the `modulestack` are NOT included in this functionality.  We strongly recommend using hard-coded values in manifests or leveraging the facilities already in place, but we have added this feature based on feedback from experienced users.
 
-Any string within your manifests that has a designated pattern will automatically be resolved.  If you have an environment variable named `SOMEKEY` that is defined, you can reference it in your manifests via wrapping it in `${}` --> for example `${SOMEKEY}`.   
+Any string within your manifests that has a designated pattern will automatically be resolved.  If you have an environment variable named `SOMEKEY` that is defined, you can reference it in your manifests via wrapping it in `${}` --> for example `${SOMEKEY}`. Additionally, it is possible to disable environment variable replacement in module input parameters using `disableEnvVarResolution: True` for cases such as when input parameter is a script.
 
 The following is a valid manifest:
 
@@ -356,6 +356,12 @@ parameters:
   - name: vpc-id
     valueFrom:
       secretsManager: ${SOMEKEY}
+  - name: param-no-env-resolution
+    disableEnvVarResolution: True
+    value:
+      - |
+        export VAR=test
+        echo "${VAR}"
 ```
 This can be applied to all values in the manifest.  We do not recommend using this in the `name` field of manifests as any value that is referenced by downstream manifests MUST align.  For example, in the following:
 

--- a/seedfarmer/models/manifests/_module_manifest.py
+++ b/seedfarmer/models/manifests/_module_manifest.py
@@ -29,7 +29,7 @@ class ModuleParameter(ValueFromRef):
     name: str
     value: Optional[Any] = None
     version: Optional[Any] = None
-    disable_env_var_resolution: Optional[bool] = None
+    disableEnvVarResolution: Optional[bool] = None
     resolved_value: Optional[Any] = None
 
     def __init__(self, **data: Any) -> None:

--- a/seedfarmer/models/manifests/_module_manifest.py
+++ b/seedfarmer/models/manifests/_module_manifest.py
@@ -29,6 +29,7 @@ class ModuleParameter(ValueFromRef):
     name: str
     value: Optional[Any] = None
     version: Optional[Any] = None
+    disable_env_var_resolution: Optional[bool] = None
     resolved_value: Optional[Any] = None
 
     def __init__(self, **data: Any) -> None:

--- a/seedfarmer/utils.py
+++ b/seedfarmer/utils.py
@@ -237,7 +237,7 @@ def batch_replace_env(payload: Dict[str, Any]) -> Dict[str, Any]:
         return working_list
 
     def recurse_dict(working_element: Dict[str, Any]) -> Dict[str, Any]:
-        if not working_element.get("disable_env_var_resolution"):
+        if not working_element.get("disableEnvVarResolution"):
             for key, value in working_element.items():
                 if isinstance(value, str):
                     working_element[key] = replace_str(value)

--- a/seedfarmer/utils.py
+++ b/seedfarmer/utils.py
@@ -237,13 +237,14 @@ def batch_replace_env(payload: Dict[str, Any]) -> Dict[str, Any]:
         return working_list
 
     def recurse_dict(working_element: Dict[str, Any]) -> Dict[str, Any]:
-        for key, value in working_element.items():
-            if isinstance(value, str):
-                working_element[key] = replace_str(value)
-            elif isinstance(value, list):
-                recurse_list(value)
-            elif isinstance(value, dict) and key not in ["deploy_spec"]:
-                recurse_dict(value)
+        if not working_element.get("disable_env_var_resolution"):
+            for key, value in working_element.items():
+                if isinstance(value, str):
+                    working_element[key] = replace_str(value)
+                elif isinstance(value, list):
+                    recurse_list(value)
+                elif isinstance(value, dict) and key not in ["deploy_spec"]:
+                    recurse_dict(value)
         return working_element
 
     payload = recurse_dict(payload)

--- a/test/unit-test/test_models.py
+++ b/test/unit-test/test_models.py
@@ -677,13 +677,13 @@ targetAccount: primary
 targetRegion: us-west-2
 parameters:
   - name: param1
-    disable_env_var_resolution: True
+    disableEnvVarResolution: True
     value:
       - |
         export VAR=test
         echo "${VAR}"
   - name: param2_nested
-    disable_env_var_resolution: True
+    disableEnvVarResolution: True
     value:
         nested_value:
           - |

--- a/test/unit-test/test_models.py
+++ b/test/unit-test/test_models.py
@@ -637,3 +637,78 @@ parameters:
     ):
         with pytest.raises(InvalidManifestError, match="The environment variable is not available: 'GIT_URL'"):
             ModuleManifest(**module_yaml)
+
+
+@pytest.mark.models
+@pytest.mark.models_module_manifest
+def test_module_manifest_with_env_var_resolution_in_script():
+    module_yaml = yaml.safe_load(
+        """
+name: test-module-1
+path: modules/test-module
+targetAccount: primary
+targetRegion: us-west-2
+parameters:
+  - name: param1
+    value:
+      - |
+        echo "${VAR}"
+"""
+    )
+
+    with mock.patch.dict(
+        os.environ,
+        {
+            "VAR": "test",
+        },
+        clear=True,
+    ):
+        ModuleManifest(**module_yaml)
+
+
+@pytest.mark.models
+@pytest.mark.models_module_manifest
+def test_module_manifest_with_env_var_resolution_in_script_disabled():
+    module_yaml = yaml.safe_load(
+        """
+name: test-module-1
+path: modules/test-module
+targetAccount: primary
+targetRegion: us-west-2
+parameters:
+  - name: param1
+    disable_env_var_resolution: True
+    value:
+      - |
+        export VAR=test
+        echo "${VAR}"
+  - name: param2_nested
+    disable_env_var_resolution: True
+    value:
+        nested_value:
+          - |
+            export VAR=test
+            echo "${VAR}"
+"""
+    )
+    ModuleManifest(**module_yaml)
+
+
+@pytest.mark.models
+@pytest.mark.models_module_manifest
+def test_module_manifest_with_env_var_resolution_in_script_error():
+    module_yaml = yaml.safe_load(
+        """
+name: test-module-1
+path: modules/test-module
+targetAccount: primary
+targetRegion: us-west-2
+parameters:
+  - name: param1
+    value:
+      - |
+        echo "${VAR}"
+"""
+    )
+    with pytest.raises(InvalidManifestError, match="The environment variable is not available: 'VAR'"):
+        ModuleManifest(**module_yaml)


### PR DESCRIPTION
*Issue #, if available:*
- https://github.com/awslabs/seed-farmer/issues/724

*Description of changes:*
- add parameter to disable env replacement in module params for cases such user passing a script as module input e.g.

```
    - eks_ng_name: ng-gdn412xlarge
      eks_node_quantity: 0
      eks_node_max_quantity: 30
      eks_node_min_quantity: 0
      eks_node_disk_size: 500
      eks_node_instance_type: "g4dn.12xlarge"
      use_gpu_ami: True
      eks_node_labels:
        usage: g4dn.12xlarge
        fast-disk-node: pv-nvme
      privateNetworking: true
      preBootstrapCommands:
        - |
          # Install NVMe CLI
          yum install nvme-cli -y
    
          # Get list of NVMe Drives
          nvme_drives=$(nvme list | grep "Amazon EC2 NVMe Instance Storage" | cut -d " " -f 1 || true)
          readarray -t nvme_drives <<< "$nvme_drives"
          'num_drives=1'
          # Install software RAID utility
          yum install mdadm -y
    
          # Create RAID-0 array across the instance store NVMe SSDs
         'mdadm --create /dev/md0 --level=0 --name=md0 --raid-devices=$num_drives "${nvme_drives[@]}"'
          # Format drive with Ext4
          mkfs.ext4 /dev/md0

          # Get RAID array's UUID
          uuid=$(blkid -o value -s UUID /dev/md0)

          # Create a filesystem path to mount the disk
          mount_location="/mnt/fast-disks/${uuid}"
          mkdir -p $mount_location
    
          # Mount RAID device
          mount /dev/md0 $mount_location
    
          # Have disk be mounted on reboot
          mdadm --detail --scan >> /etc/mdadm.conf 
          echo /dev/md0 $mount_location ext4 defaults,noatime 0 2 >> /etc/fstab
```
- supports nested parameters such as frequently used in [idf/compute/eks](https://github.com/awslabs/idf-modules/tree/main/modules/compute/eks) module
- add test cases
- update docs

Usage:
```
name: test-module-1
path: modules/test-module
targetAccount: primary
targetRegion: us-west-2
parameters:
  - name: param1
    disableEnvVarResolution: True
    value:
      - |
        export VAR=test
        echo "${VAR}"
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
