### PR TITLE
chore: Adds `seedfarmer --version`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 
 ### Changes
 
+- Adds `seedfarmer --version` to validate package without running explicit command
 - Added ability to disable env replacement in module parameters
 
 ### Fixes

--- a/seedfarmer/__main__.py
+++ b/seedfarmer/__main__.py
@@ -28,6 +28,7 @@ _logger: logging.Logger = logging.getLogger(__name__)
 
 
 @click.group()
+@click.version_option(seedfarmer.__version__)
 def cli() -> None:
     """SeedFarmer CLI interface"""
     pass


### PR DESCRIPTION
*Issue #, if available:*
Raised internally.

If a user wants to validate installation without running an explicit CLI command e.g. `seedfarmer version`:
`seedfarmer.yaml` is required in the path. 

```bash
seedfarmer.errors.seedfarmer_errors.SeedFarmerException: The seedfarmer.yaml was not found at the root of your project. Please set it and rerun.
```

*Description of changes:*
- Adds click CLI global option `--version` to allow package invoke entrypoint without running all validations.

### Usage
```bash
> seedfarmer --version
seedfarmer, version 5.1.0.dev0
```

### Additional Impact
This seems to also allow `--help` to execute without imports as well.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
