### PR TITLE
fix: sts pass toolchain region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 - Added ability to disable env replacement in module parameters
 - Updating bootstrap docs with minimum permissions
 - Update manifest example module versions
+- Update session manager to pass toolchain role region to sts
 
 ### Fixes
 

--- a/seedfarmer/services/session_manager.py
+++ b/seedfarmer/services/session_manager.py
@@ -140,6 +140,7 @@ class SessionManager(ISessionManager, metaclass=SingletonMeta):
         session_key = f"{account_id}-{region_name}"
         project_name = self.config["project_name"]
         qualifier = self.config.get("qualifier") if self.config.get("qualifier") else None
+        toolchain_region = self.config.get("toolchain_region")
         if not self.created:
             raise seedfarmer.errors.InvalidConfigurationError("The SessionManager object was never properly created...")
         if session_key not in self.sessions.keys():
@@ -152,6 +153,7 @@ class SessionManager(ISessionManager, metaclass=SingletonMeta):
                 aws_access_key_id=toolchain_role["Credentials"]["AccessKeyId"],
                 aws_secret_access_key=toolchain_role["Credentials"]["SecretAccessKey"],
                 aws_session_token=toolchain_role["Credentials"]["SessionToken"],
+                region_name=toolchain_region if toolchain_region else region_name,
             )
             partition = sts_toolchain_client.get_caller_identity()["Arn"].split(":")[1]
             deployment_role_arn = get_deployment_role_arn(


### PR DESCRIPTION
*Relates:*
- https://github.com/awslabs/seed-farmer/issues/223
- https://github.com/awslabs/seed-farmer/issues/690

The issue persists on `destroy` in `cn-north-1` region:

```
seedfarmer destroy <REDACTED> --profile default --region cn-north-1 --debug

[2024-10-29 16:48:38,385 | INFO | utils.py     :198 | MainThread ] Loading environment variables from .env
[2024-10-29 16:48:38,386 | INFO | main.py      : 62 | MainThread ] Python-dotenv could not find configuration file /Volumes/workplace/github.com/idf-modules/.env.
[2024-10-29 16:48:38,386 | INFO | main.py      : 62 | MainThread ] Python-dotenv could not find configuration file /Volumes/workplace/github.com/idf-modules/.env.
[2024-10-29 16:48:38,386 | DEBUG | utils.py     :204 | MainThread ] Loaded environment variables: {}
[2024-10-29 16:48:38,386 | DEBUG | __main__.py  :265 | MainThread ] Listing all deployments for Project idf
[2024-10-29 16:48:38,386 | INFO | __main__.py  :267 | MainThread ] Destroy for Project idf, Deployment local-idf
[2024-10-29 16:48:38,386 | DEBUG | _deployment_commands.py:930 | MainThread ] Preparing to destroy local-idf
[2024-10-29 16:48:38,387 | INFO | session_manager.py:196 | MainThread ] Creating toolchain session
[2024-10-29 16:48:38,387 | DEBUG | session_manager.py:206 | MainThread ] Creating a local session with the following info passed in:
                      region_name = cn-north-1
                      profile_name = default
                      project_name = idf
                      qualifier = None

                      NOTE: if not set here, the active environment parameters are used to create a new AWS session
                            much like how the AWS CLI operates.
                      
[2024-10-29 16:48:38,411 | DEBUG | _service_utils.py: 36 | MainThread ] Proxies Configured: {'http': None, 'https': None}
[2024-10-29 16:48:40,582 | DEBUG | session_manager.py:225 | MainThread ] The active user session will assume the toolchain role
                      arn = arn:aws-cn:iam::<REDACTED>:role/seedfarmer-idf-toolchain-role
                      toolchain_region = None
                      
[2024-10-29 16:48:40,582 | DEBUG | _service_utils.py: 36 | MainThread ] Proxies Configured: {'http': None, 'https': None}
[2024-10-29 16:48:41,984 | DEBUG | _service_utils.py: 36 | MainThread ] Proxies Configured: {'http': None, 'https': None}
[2024-10-29 16:48:44,196 | DEBUG | _service_utils.py: 36 | MainThread ] Proxies Configured: {'http': None, 'https': None}
[2024-10-29 16:48:45,679 | INFO | session_manager.py:143 | ThreadPoolExecutor-0_0 ] Creating Session for <REDACTED>-cn-north-1
[2024-10-29 16:48:45,696 | DEBUG | _service_utils.py: 36 | ThreadPoolExecutor-0_0 ] Proxies Configured: {'http': None, 'https': None}

[2024-10-29 11:32:18,640 | INFO | session_manager.py:143 | ThreadPoolExecutor-0_0 ] Creating Session for <REDACTED>-cn-north-1
Traceback (most recent call last):
  File "/Volumes/<REDACTED/.venv/bin/seedfarmer", line 8, in <module>
    sys.exit(main())
  File "/Volumes/<REDACTED/.venv/lib/python3.9/site-packages/seedfarmer/__main__.py", line 296, in main
    cli()
  File "/Volumes/<REDACTED/.venv/lib/python3.9/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/Volumes/<REDACTED/.venv/lib/python3.9/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/Volumes/<REDACTED/.venv/lib/python3.9/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Volumes/<REDACTED/.venv/lib/python3.9/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Volumes/<REDACTED/.venv/lib/python3.9/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/Volumes/<REDACTED/.venv/lib/python3.9/site-packages/seedfarmer/__main__.py", line 271, in destroy
    commands.destroy(
  File "/Volumes/<REDACTED/.venv/lib/python3.9/site-packages/seedfarmer/commands/_deployment_commands.py", line 939, in destroy
    destroy_manifest = du.generate_deployed_manifest(deployment_name=deployment_name, skip_deploy_spec=False)
  File "/Volumes/<REDACTED/.venv/lib/python3.9/site-packages/seedfarmer/mgmt/deploy_utils.py", line 393, in generate_deployed_manifest
    module_info_index = populate_module_info_index(deployment_manifest=deployed_manifest)
  File "/Volumes/<REDACTED/.venv/lib/python3.9/site-packages/seedfarmer/mgmt/deploy_utils.py", line 119, in populate_module_info_index
    _ = list(workers.map(_get_module_info, params))
  File "/usr/local/Cellar/python@3.9/3.9.18_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/concurrent/futures/_base.py", line 609, in result_iterator
    yield fs.pop().result()
  File "/usr/local/Cellar/python@3.9/3.9.18_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/concurrent/futures/_base.py", line 446, in result
    return self.__get_result()
  File "/usr/local/Cellar/python@3.9/3.9.18_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/concurrent/futures/_base.py", line 391, in __get_result
    raise self._exception
  File "/usr/local/Cellar/python@3.9/3.9.18_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/Volumes/<REDACTED/.venv/lib/python3.9/site-packages/seedfarmer/mgmt/deploy_utils.py", line 100, in _get_module_info
    SessionManager()
  File "/Volumes/<REDACTED/.venv/lib/python3.9/site-packages/seedfarmer/services/session_manager.py", line 153, in get_deployment_session
    partition = sts_toolchain_client.get_caller_identity().get("Arn").split(":")[1]
  File "/Volumes/<REDACTED/.venv/lib/python3.9/site-packages/botocore/client.py", line 553, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/Volumes/<REDACTED/.venv/lib/python3.9/site-packages/botocore/client.py", line 1009, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (InvalidClientTokenId) when calling the GetCallerIdentity operation: The security token included in the request is invalid
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
