### PR TITLE
fix support for nested modules in archives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 - Update session manager to pass toolchain role region to sts
 
 ### Fixes
+- allow nested modules in archives pulled over HTTPS (ref issue/749)
 
 ## v5.0.0 (2024-08-16)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ markers = [
     "mgmt_metadata_support: marks all `mgmt_metadata_support` tests",
     "mgmt_build_info: marks all `mgmt_build_info` tests",
     "mgmt_git_support: marks all `mgmt_git_support` tests",
+    "mgmt_git_release:  marks all `mgmt_git_release` tests",
     "mgmt_archive_support: marks all `mgmt_archive_support` tests",
     "service: marks all `services` tests",
     "projectpolicy: marks all `projectpolicy` tests",

--- a/seedfarmer/mgmt/archive_support.py
+++ b/seedfarmer/mgmt/archive_support.py
@@ -17,7 +17,6 @@ import logging
 import os.path
 import pathlib
 import re
-import shutil
 import tarfile
 from typing import Optional, Tuple
 from urllib.parse import parse_qs, urlparse
@@ -90,16 +89,9 @@ def _process_archive(archive_name: str, response: Response, extracted_dir: str) 
         archive_file.write(response.content)
 
     extracted_dir_path = os.path.join(parent_dir, extracted_dir)
-    embedded_dir = _extract_archive(archive_name, extracted_dir_path)
+    _ = _extract_archive(archive_name, extracted_dir_path)
 
     os.remove(archive_name)
-
-    if embedded_dir:
-        file_names = os.listdir(os.path.join(extracted_dir_path, embedded_dir))
-        for file_name in file_names:
-            shutil.move(os.path.join(extracted_dir_path, embedded_dir, file_name), extracted_dir_path)
-
-        os.rmdir(os.path.join(extracted_dir_path, embedded_dir))
 
     return extracted_dir_path
 


### PR DESCRIPTION
*Issue #, if available:*
#749 

*Description of changes:*
SF was trying to enforce modules to be at the root within an archive.  This change allows nested modules with backward compatibility support. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
