### PR TITLE
Revert "fix support for nested modules in archives"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,6 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 
 ### Changes
 
-### Fixes
-
-
-## v5.0.1 (2024-12-02)
-
-### New 
-
-### Changes
-
 - Adds `seedfarmer --version` to validate package without running explicit command
 - Added ability to disable env replacement in module parameters
 - Updating bootstrap docs with minimum permissions
@@ -25,7 +16,6 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 - Update session manager to pass toolchain role region to sts
 
 ### Fixes
-- allow nested modules in archives pulled over HTTPS (ref issue/749)
 
 ## v5.0.0 (2024-08-16)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,6 @@ markers = [
     "mgmt_metadata_support: marks all `mgmt_metadata_support` tests",
     "mgmt_build_info: marks all `mgmt_build_info` tests",
     "mgmt_git_support: marks all `mgmt_git_support` tests",
-    "mgmt_git_release:  marks all `mgmt_git_release` tests",
     "mgmt_archive_support: marks all `mgmt_archive_support` tests",
     "service: marks all `services` tests",
     "projectpolicy: marks all `projectpolicy` tests",

--- a/seedfarmer/mgmt/archive_support.py
+++ b/seedfarmer/mgmt/archive_support.py
@@ -17,6 +17,7 @@ import logging
 import os.path
 import pathlib
 import re
+import shutil
 import tarfile
 from typing import Optional, Tuple
 from urllib.parse import parse_qs, urlparse
@@ -89,9 +90,16 @@ def _process_archive(archive_name: str, response: Response, extracted_dir: str) 
         archive_file.write(response.content)
 
     extracted_dir_path = os.path.join(parent_dir, extracted_dir)
-    _ = _extract_archive(archive_name, extracted_dir_path)
+    embedded_dir = _extract_archive(archive_name, extracted_dir_path)
 
     os.remove(archive_name)
+
+    if embedded_dir:
+        file_names = os.listdir(os.path.join(extracted_dir_path, embedded_dir))
+        for file_name in file_names:
+            shutil.move(os.path.join(extracted_dir_path, embedded_dir, file_name), extracted_dir_path)
+
+        os.rmdir(os.path.join(extracted_dir_path, embedded_dir))
 
     return extracted_dir_path
 


### PR DESCRIPTION
This reverts commit d9c2053a716ed80c9bfeefe408c25ae7cd3156bc.



*Description of changes:*
The archive support was damaged, reverting and need to address dependabot library changes for pydantic and typing

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
