### PR TITLE
limit extraction dir to one on archives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 - Update session manager to pass toolchain role region to sts
 
 ### Fixes
+- correct archive extraction when there is only one nested path (issue 749)
 
 ## v5.0.0 (2024-08-16)
 

--- a/seedfarmer/mgmt/archive_support.py
+++ b/seedfarmer/mgmt/archive_support.py
@@ -74,7 +74,11 @@ def _extract_archive(archive_name: str, extracted_dir_path: str) -> str:
         with tarfile.open(archive_name, "r:gz") as tar_file:
             all_members = tar_file.getmembers()
             top_level_dirs = set(member.name.split("/")[0] for member in all_members)
-            if len(top_level_dirs) == 1:
+            if len(top_level_dirs) > 1:
+                raise InvalidConfigurationError(
+                    f"the archive {archive_name} can only have one directory at the root and no files"
+                )
+            elif len(top_level_dirs) == 1:
                 embedded_dir = top_level_dirs.pop()
             else:
                 embedded_dir = ""
@@ -83,16 +87,18 @@ def _extract_archive(archive_name: str, extracted_dir_path: str) -> str:
     else:
         with ZipFile(archive_name, "r") as zip_file:
             all_files = zip_file.namelist()
-            top_level_dirs = set(name.split("/")[0] for name in all_files if name.endswith("/"))
-            if len(top_level_dirs) == 1:
+            top_level_dirs = set(name.split("/")[0] for name in all_files)
+            if len(top_level_dirs) > 1:
+                raise InvalidConfigurationError(
+                    f"the archive {archive_name} can only have one directory at the root and no files"
+                )
+            elif len(top_level_dirs) == 1:
                 embedded_dir = top_level_dirs.pop()
             else:
                 embedded_dir = ""
-            files_to_extract = [f for f in all_files]  # ]
-
+            files_to_extract = [f for f in all_files]
             for file in files_to_extract:
                 zip_file.extract(file, path=extracted_dir_path)
-
     return embedded_dir
 
 

--- a/seedfarmer/mgmt/archive_support.py
+++ b/seedfarmer/mgmt/archive_support.py
@@ -82,8 +82,7 @@ def _extract_archive(archive_name: str, extracted_dir_path: str) -> str:
                 embedded_dir = top_level_dirs.pop()
             else:
                 embedded_dir = ""
-            members_to_extract = [m for m in all_members]
-            tar_file.extractall(extracted_dir_path, members=members_to_extract)
+            tar_file.extractall(extracted_dir_path, members=all_members)
     else:
         with ZipFile(archive_name, "r") as zip_file:
             all_files = zip_file.namelist()
@@ -96,8 +95,7 @@ def _extract_archive(archive_name: str, extracted_dir_path: str) -> str:
                 embedded_dir = top_level_dirs.pop()
             else:
                 embedded_dir = ""
-            files_to_extract = [f for f in all_files]
-            for file in files_to_extract:
+            for file in all_files:
                 zip_file.extract(file, path=extracted_dir_path)
     return embedded_dir
 

--- a/seedfarmer/mgmt/archive_support.py
+++ b/seedfarmer/mgmt/archive_support.py
@@ -73,7 +73,7 @@ def _extract_archive(archive_name: str, extracted_dir_path: str) -> str:
     if archive_name.endswith(".tar.gz"):
         with tarfile.open(archive_name, "r:gz") as tar_file:
             all_members = tar_file.getmembers()
-            top_level_dirs = set(member.name.split("/")[0] for member in all_members)
+            top_level_dirs = set(member.name.split("/")[0] for member in all_members if "/" in member.name)
             if len(top_level_dirs) > 1:
                 raise InvalidConfigurationError(
                     f"the archive {archive_name} can only have one directory at the root and no files"
@@ -87,7 +87,7 @@ def _extract_archive(archive_name: str, extracted_dir_path: str) -> str:
     else:
         with ZipFile(archive_name, "r") as zip_file:
             all_files = zip_file.namelist()
-            top_level_dirs = set(name.split("/")[0] for name in all_files)
+            top_level_dirs = set(name.split("/")[0] for name in all_files if "/" in name)
             if len(top_level_dirs) > 1:
                 raise InvalidConfigurationError(
                     f"the archive {archive_name} can only have one directory at the root and no files"

--- a/test/unit-test/test_mgmt_archive_support.py
+++ b/test/unit-test/test_mgmt_archive_support.py
@@ -353,6 +353,7 @@ def test_fetch_module_repo_from_s3_non_nested(
         assert os.path.exists(os.path.join(archive_path, "deployspec.yaml"))
         assert subdir == "./"
 
+
 @pytest.mark.mgmt
 @pytest.mark.mgmt_archive_support
 @pytest.mark.parametrize(
@@ -380,7 +381,7 @@ def test_fetch_module_repo_from_s3_single_module(
         assert "x-amz-content-sha256" in mock_requests_get.call_args.kwargs["headers"]
         assert "Authorization" in mock_requests_get.call_args.kwargs["headers"]
         assert os.path.exists(os.path.join(archive_path, module_name, "deployspec.yaml"))
-        assert subdir=="modules/test-module/"
+        assert subdir == "modules/test-module/"
 
 
 @pytest.mark.mgmt

--- a/test/unit-test/test_mgmt_archive_support.py
+++ b/test/unit-test/test_mgmt_archive_support.py
@@ -84,23 +84,30 @@ example_archive_files = [
     ("test-project/modules/test-module/pyproject.toml", io.BytesIO(b"222")),
     ("test-project/README.md", io.BytesIO(b"333")),
     ("test-project/LICENSE", io.BytesIO(b"444")),
+    (".DS_Store_local", io.BytesIO(b"555")),
 ]
 
 example_archive_files_single_module = [
-    ("test-project/modules/test-module/deployspec.yaml", io.BytesIO(b"111")),
-    ("test-project/modules/test-module/something.yaml", io.BytesIO(b"111")),
+    ("test-project/modules/test-module/deployspec.yaml", io.BytesIO(b"666")),
+    ("test-project/modules/test-module/something.yaml", io.BytesIO(b"777")),
+    (".DS_Store", io.BytesIO(b"888")),
+    ("README.md", io.BytesIO(b"999")),
 ]
 
 example_archive_files_no_nesting = [
-    ("test-project/deployspec.yaml", io.BytesIO(b"111")),
-    ("test-project/app.py", io.BytesIO(b"111")),
-    ("test-project/stack.py", io.BytesIO(b"111")),
+    ("deployspec.yaml", io.BytesIO(b"1010")),
+    ("app.py", io.BytesIO(b"1011")),
+    ("stack.py", io.BytesIO(b"1012")),
+    (".DS_Store", io.BytesIO(b"1013")),
+    ("README.md", io.BytesIO(b"1014")),
 ]
 
 example_archive_files_bad_structure = [
-    ("deployspec.yaml", io.BytesIO(b"111")),
-    ("app.py", io.BytesIO(b"111")),
-    ("stack.py", io.BytesIO(b"111")),
+    ("test-project/deployspec.yaml", io.BytesIO(b"1200")),
+    ("test-project_additional/deployspec.yaml", io.BytesIO(b"1201")),
+    ("deployspec.yaml", io.BytesIO(b"1202")),
+    ("app.py", io.BytesIO(b"1203")),
+    ("stack.py", io.BytesIO(b"1204")),
 ]
 
 
@@ -218,7 +225,7 @@ def archive_file_data_single_module(
 
 
 @pytest.fixture(params=["zip_file_data_bad_structure", "tar_file_data_bad_structure"])
-def archive_file_data_single_bad_structure(
+def archive_file_data_bad_structure(
     request: pytest.FixtureRequest,
     zip_file_data_bad_structure: Tuple[bytes, str],
     tar_file_data_bad_structure: Tuple[bytes, str],
@@ -382,9 +389,9 @@ def test_fetch_module_repo_from_s3_single_module(
     "s3_bucket_http_url", ["testing-bucket.s3.amazonaws.com", "testing-bucket.s3.us-west-2.amazonaws.com"]
 )
 def test_fetch_module_repo_bad_archive_structure(
-    session_manager: None, archive_file_data_single_bad_structure: Tuple[bytes, str], s3_bucket_http_url: str
+    session_manager: None, archive_file_data_bad_structure: Tuple[bytes, str], s3_bucket_http_url: str
 ) -> None:
-    archive_bytes, archive_extension = archive_file_data_single_bad_structure
+    archive_bytes, archive_extension = archive_file_data_bad_structure
 
     response_mock = MagicMock()
     response_mock.status_code = 200

--- a/test/unit-test/test_mgmt_archive_support.py
+++ b/test/unit-test/test_mgmt_archive_support.py
@@ -79,6 +79,9 @@ def parent_dir_prepare():
         shutil.rmtree(parent_dir)
 
 
+# This represents a proper archive with the project (test-project) at the root
+# are are ignoring the hidden file at the root, and the other files
+# under test-project are not used
 example_archive_files = [
     ("test-project/modules/test-module/modulestack.yaml", io.BytesIO(b"111")),
     ("test-project/modules/test-module/pyproject.toml", io.BytesIO(b"222")),
@@ -87,6 +90,8 @@ example_archive_files = [
     (".DS_Store_local", io.BytesIO(b"555")),
 ]
 
+# This represents a proper archive with the project (test-project) at the root
+# are are ignoring the hidden file at the root, and the other file is not used
 example_archive_files_single_module = [
     ("test-project/modules/test-module/deployspec.yaml", io.BytesIO(b"666")),
     ("test-project/modules/test-module/something.yaml", io.BytesIO(b"777")),
@@ -94,6 +99,9 @@ example_archive_files_single_module = [
     ("README.md", io.BytesIO(b"999")),
 ]
 
+# This represents a an archive without a nested dir (project)
+# This is not recommended as it is not a proper SF project,
+# but can support due to customer ask
 example_archive_files_no_nesting = [
     ("deployspec.yaml", io.BytesIO(b"1010")),
     ("app.py", io.BytesIO(b"1011")),
@@ -102,6 +110,8 @@ example_archive_files_no_nesting = [
     ("README.md", io.BytesIO(b"1014")),
 ]
 
+# This is a bad package as there are two dirs at the
+# root level...that is not allowed
 example_archive_files_bad_structure = [
     ("test-project/deployspec.yaml", io.BytesIO(b"1200")),
     ("test-project_additional/deployspec.yaml", io.BytesIO(b"1201")),

--- a/test/unit-test/test_mgmt_archive_support.py
+++ b/test/unit-test/test_mgmt_archive_support.py
@@ -310,8 +310,7 @@ def test_fetch_module_repo_from_s3(
     with patch("requests.get", return_value=response_mock) as mock_requests_get:
         archive_path_test = f"archive::{s3_http_url}?module={module_name}"
 
-        archive_path, _ = archive.fetch_archived_module(release_path=archive_path_test)
-        archive.fetch_archived_module(release_path=archive_path_test)
+        archive_path, subdir = archive.fetch_archived_module(release_path=archive_path_test)
         mock_requests_get.assert_called_once()
 
         assert mock_requests_get.call_args.kwargs["url"] == s3_http_url
@@ -319,9 +318,9 @@ def test_fetch_module_repo_from_s3(
         # check that the sha256 header was added and that the request was signed
         assert "x-amz-content-sha256" in mock_requests_get.call_args.kwargs["headers"]
         assert "Authorization" in mock_requests_get.call_args.kwargs["headers"]
-
         # Check that the module was extracted to the correct location
         assert os.path.exists(os.path.join(archive_path, module_name, "modulestack.yaml"))
+        assert subdir == "modules/test-module/"
 
 
 @pytest.mark.mgmt
@@ -352,7 +351,7 @@ def test_fetch_module_repo_from_s3_non_nested(
         assert "Authorization" in mock_requests_get.call_args.kwargs["headers"]
 
         assert os.path.exists(os.path.join(archive_path, "deployspec.yaml"))
-
+        assert subdir == "./"
 
 @pytest.mark.mgmt
 @pytest.mark.mgmt_archive_support
@@ -381,6 +380,7 @@ def test_fetch_module_repo_from_s3_single_module(
         assert "x-amz-content-sha256" in mock_requests_get.call_args.kwargs["headers"]
         assert "Authorization" in mock_requests_get.call_args.kwargs["headers"]
         assert os.path.exists(os.path.join(archive_path, module_name, "deployspec.yaml"))
+        assert subdir=="modules/test-module/"
 
 
 @pytest.mark.mgmt


### PR DESCRIPTION
*Issue #, if available:*
#749 
*Description of changes:*
The extraction of an archive with only one dir and nested dir fails due to implementation logic.  This forces the extraction to follow the seedfarmer project structure to only extract one nested dir down.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
