### PR TITLE
correct the reference to account for boundary policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 
 ### Fixes
 - correct archive extraction when there is only one nested path (issue 749)
+- force proper resolution of boundary permissions
 
 ## v5.0.0 (2024-08-16)
 

--- a/seedfarmer/models/manifests/_deployment_manifest.py
+++ b/seedfarmer/models/manifests/_deployment_manifest.py
@@ -448,7 +448,7 @@ class DeploymentManifest(CamelModel):
     def get_permission_boundary_arn(self, target_account: str, target_region: str) -> Optional[str]:
         permissions_boundary_name = self.get_parameter_value(
             "permissionsBoundaryName",
-            account_alias=target_account,
+            account_id=target_account,
             region=target_region,
         )
         return (

--- a/seedfarmer/models/transfer/_module_deploy_object.py
+++ b/seedfarmer/models/transfer/_module_deploy_object.py
@@ -26,7 +26,7 @@ class ModuleDeployObject(CamelModel):
         _module = cast(ModuleManifest, self.deployment_manifest.get_module(self.group_name, self.module_name))
 
         pba = self.deployment_manifest.get_permission_boundary_arn(
-            target_account=cast(str, _module.target_account),
+            target_account=cast(str, _module.get_target_account_id()),
             target_region=cast(str, _module.target_region),
         )
         codebuild_image = self.deployment_manifest.get_region_codebuild_image(

--- a/test/unit-test/mock_data/mock_deployment_manifest_huge.py
+++ b/test/unit-test/mock_data/mock_deployment_manifest_huge.py
@@ -241,7 +241,10 @@ deployment_manifest = {
             "alias": "primary",
             "account_id": "123456789012",
             "default": True,
-            "parameters_global": {"dockerCredentialsSecret": "aws-addf-docker-credentials"},
+            "parameters_global": {
+                "dockerCredentialsSecret": "aws-addf-docker-credentials",
+                "permissionsBoundaryName": "boundary",
+            },
             "region_mappings": [
                 {
                     "region": "us-east-1",

--- a/test/unit-test/test_commands_deployment.py
+++ b/test/unit-test/test_commands_deployment.py
@@ -1,5 +1,6 @@
 import json
 import os
+from unittest.mock import ANY
 
 import mock_data.mock_deployment_manifest_for_destroy as mock_deployment_manifest_for_destroy
 import mock_data.mock_deployment_manifest_huge as mock_deployment_manifest_huge
@@ -293,7 +294,9 @@ def test_create_module_deployment_role(session_manager, mocker):
         "seedfarmer.commands._deployment_commands.get_generic_module_deployment_role_name",
         return_value="generic-module-deployment-role",
     )
-    mocker.patch("seedfarmer.commands._deployment_commands.create_module_deployment_role", return_value=None)
+    mock_create_module_deployment_role = mocker.patch(
+        "seedfarmer.commands._deployment_commands.create_module_deployment_role", return_value=None
+    )
 
     dep = DeploymentManifest(**mock_deployment_manifest_huge.deployment_manifest)
     dep.validate_and_set_module_defaults()
@@ -302,6 +305,14 @@ def test_create_module_deployment_role(session_manager, mocker):
         account_id="123456789012",
         region="us-east-1",
         deployment_manifest=dep,
+    )
+
+    mock_create_module_deployment_role.assert_called_once_with(
+        role_name="generic-module-deployment-role",
+        deployment_name="mlops",
+        permissions_boundary_arn="arn:aws:iam::123456789012:policy/boundary",
+        docker_credentials_secret=None,
+        session=ANY,
     )
 
 

--- a/test/unit-test/test_models.py
+++ b/test/unit-test/test_models.py
@@ -121,6 +121,12 @@ def test_deployment_manifest_get_parameter_with_defaults():
     with pytest.raises(seedfarmer.errors.InvalidManifestError):
         manifest.get_target_account_mapping()
 
+    assert manifest.get_parameter_value("permissionsBoundaryName") == "policyName"
+    assert (
+        manifest.get_permission_boundary_arn(target_account="000000000000", target_region="us-west-2")
+        == "arn:aws:iam::000000000000:policy/policyName"
+    )
+
 
 @pytest.mark.models
 @pytest.mark.models_deployment_manifest


### PR DESCRIPTION
*Issue #, if available:*
#758 
*Description of changes:*
The account referenced to generate the boundary policy arn was using the alias, not the account id.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
