### PR TITLE
Do not depend on pkg_resources/setuptools, prefer native modules.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ### Changes
 
 ### Fixes
+- No longer depends on the `pkg_resources` module being available from the setuptools package.
 
 ## v5.0.0 (2024-08-16)
 

--- a/seedfarmer/__init__.py
+++ b/seedfarmer/__init__.py
@@ -16,9 +16,9 @@
 import logging
 import os
 import pathlib
+from importlib.metadata import distribution
 from typing import Any, Dict, Optional, cast
 
-import pkg_resources
 import yaml
 from aws_codeseeder import LOGGER, codeseeder
 from aws_codeseeder.codeseeder import CodeSeederConfig
@@ -30,7 +30,7 @@ from seedfarmer.models import ProjectSpec
 
 _logger: logging.Logger = logging.getLogger(__name__)
 __all__ = ["__description__", "__license__", "__title__"]
-__version__: str = pkg_resources.get_distribution(__title__).version
+__version__: str = distribution(__title__).version
 
 DEBUG_LOGGING_FORMAT = "[%(asctime)s][%(filename)-13s:%(lineno)3d] %(message)s"
 INFO_LOGGING_FORMAT = "[%(asctime)s | %(levelname)s | %(filename)-13s:%(lineno)3d | %(threadName)s ] %(message)s"


### PR DESCRIPTION
*Issue #, if available:*
N/A

This is essentially the same as awslabs/aws-codeseeder#285 and will need that to fully be able to not need setuptools installed, but does not require it.

*Description of changes:*
If your environment doesn't have `setuptools` installed (to provide the `pkg_resources` module) then the main seed-farmer would fail to initialize, two options to fix this were:

1. Add `setuptools` as a requirement of seed-farmer itself (instead of depending on it to exist in the environment already). (This wouldn't fully fix the issue due to the dependency on codeseeder, see above.)
2. Stop using `pkg_resources`.

I chose the second option since a native module ([`importlib.metadata`](https://docs.python.org/3/library/importlib.metadata.html#importlib.metadata.distribution)) can be used as a replacement (introduced in Python 3.8, which is the minimum version of seed-farmer).

Note that this doesn't happen when running in CodeDeploy due to [setuptools being installed in the base image](https://github.com/aws/aws-codebuild-docker-images/blob/2898ad3dfbe414b5a09b5850cedd23ac39d2af2d/ubuntu/standard/6.0/Dockerfile#L224).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
