### PR TITLE
fix: add usedforsecurity=False to hashlib.md5 to indicate it is not used in a security context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 
 ### Fixes
 
+- add usedforsecurity=False to md5 hash to indicate it is not used in security context
 
 ## v6.0.0 (2025-01-21)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ exclude = [
     "seedfarmer.gitmodules"
 ]
 line-length = 120
-target-version = "py38"
+target-version = "py39"
 
 [tool.ruff.lint]
 select = ["E", "W", "F", "I"]
@@ -28,7 +28,7 @@ fixable = ["ALL"]
 "test/unit-test/mock_data/*" = ["E501"]
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.9"
 strict = true
 ignore_missing_imports = true
 disallow_untyped_decorators = false

--- a/seedfarmer/commands/_deployment_commands.py
+++ b/seedfarmer/commands/_deployment_commands.py
@@ -680,9 +680,10 @@ def deploy_deployment(
             )
 
             module.manifest_md5 = hashlib.md5(
-                json.dumps(module.model_dump(), sort_keys=True).encode("utf-8")
+                json.dumps(module.model_dump(), sort_keys=True).encode("utf-8"),
+                usedforsecurity=False,
             ).hexdigest()
-            module.deployspec_md5 = hashlib.md5(open(deployspec_path, "rb").read()).hexdigest()
+            module.deployspec_md5 = hashlib.md5(open(deployspec_path, "rb").read(), usedforsecurity=False).hexdigest()
 
             _build_module = du.need_to_build(
                 deployment_name=deployment_name,


### PR DESCRIPTION
*Description of changes:*
- Add usedforsecurity=False to hashlib.md5 to indicate it is not used in a security context
- Switch ruff/mypy to Python 3.9

https://docs.python.org/3/library/hashlib.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
