### PR TITLE
fix: executing jq via shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 
 ### Fixes
 - No longer depends on the `pkg_resources` module being available from the setuptools package.
-- add usedforsecurity=False to md5 hash to indicate it is not used in security context
+- add usedforsecurity=False to md5 and sha1 hashing functions to indicate they are not used in security context
 - fix executing jq via shell
 
 ## v6.0.0 (2025-01-21)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 
 ### Fixes
 - No longer depends on the `pkg_resources` module being available from the setuptools package.
-
 - add usedforsecurity=False to md5 hash to indicate it is not used in security context
+- fix executing jq via shell
 
 ## v6.0.0 (2025-01-21)
 

--- a/seedfarmer/mgmt/metadata_support.py
+++ b/seedfarmer/mgmt/metadata_support.py
@@ -166,9 +166,8 @@ def convert_cdkexports(
     else:
         clean_jq_path = _clean_jq(jq_path)
         _logger.info("Pulling with jq path '%s' from %s file", clean_jq_path, json_file)
-        with open("tmp-metadata", "w") as outfile:
-            cat_process = subprocess.Popen(["cat", cdk_output_path], stdout=subprocess.PIPE, shell=False)
-            subprocess.run(["jq", clean_jq_path], stdin=cat_process.stdout, stdout=outfile, shell=False)
+        with open(cdk_output_path, "r") as infile, open("tmp-metadata", "w") as outfile:
+            subprocess.run(["jq", clean_jq_path], stdin=infile, stdout=outfile, shell=False)
         data = json.loads(open("tmp-metadata", "r").read())
 
     existing_metadata = _read_metadata_file(mms)

--- a/seedfarmer/mgmt/metadata_support.py
+++ b/seedfarmer/mgmt/metadata_support.py
@@ -15,6 +15,7 @@
 import json
 import logging
 import os
+import subprocess
 from pathlib import Path
 from typing import Any, Dict, Optional, Tuple, cast
 
@@ -164,10 +165,10 @@ def convert_cdkexports(
         data = cdk_output[out_key]["metadata"]
     else:
         clean_jq_path = _clean_jq(jq_path)
-        jq_command = f"cat {cdk_output_path} | jq '{clean_jq_path}'"
         _logger.info("Pulling with jq path '%s' from %s file", clean_jq_path, json_file)
-        _logger.debug(f"The entire jq command: {jq_command}")
-        os.system(f"{jq_command} > tmp-metadata")
+        with open("tmp-metadata", "w") as outfile:
+            cat_process = subprocess.Popen(["cat", cdk_output_path], stdout=subprocess.PIPE, shell=False)
+            subprocess.run(["jq", clean_jq_path], stdin=cat_process.stdout, stdout=outfile, shell=False)
         data = json.loads(open("tmp-metadata", "r").read())
 
     existing_metadata = _read_metadata_file(mms)

--- a/seedfarmer/utils.py
+++ b/seedfarmer/utils.py
@@ -70,7 +70,7 @@ def upper_snake_case(value: str) -> str:
 
 
 def generate_hash(string: str, length: int = 8) -> str:
-    return (hashlib.sha1(string.encode("UTF-8")).hexdigest())[:length]
+    return (hashlib.sha1(string.encode("UTF-8"), usedforsecurity=False).hexdigest())[:length]
 
 
 def generate_session_hash(session: Optional[Session] = None) -> str:


### PR DESCRIPTION
*Description of changes:*
-  executing jq via shell
- add usedforsecurity=False to sha1 to indicate it is not used in security context

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
