### PR TITLE
ignore changes to dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -13,6 +13,12 @@ updates:
       - dependency-name: "myst_parser"
         versions:
           - "4.0.0"
+      - dependency-name: "pydantic"
+        versions:
+          - "2.10.5"
+      - dependency-name: "pydantic-core"
+        versions:
+          - "2.27.2"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Excluding versions of pydantic and pydantic-core from dependabot to maintain consistency.  If pydantic needs updates due to security flaws, the should be updated manually and checked

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
