### PR TITLE
Fix: Add deny actions to deployment role

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,57 @@
+.PHONY: help test validate format install clean
+
+# Default target when just running 'make'
+.DEFAULT_GOAL := help
+
+.PHONY: install
+install:  ## Install dependencies
+	@echo "Setting up virtual environment..."
+	python3 -m venv .venv
+	@echo "Installing Dev dependencies..."
+	. .venv/bin/activate && \
+	python -m pip install --upgrade pip && \
+	pip install -r requirements.txt && \
+	pip install -r requirements-dev.txt && \
+	pip install -e .
+
+.PHONY: test
+test:  ## Run unit tests
+	@echo "Running unit tests..."
+	. .venv/bin/activate && ./test/pytest.sh
+
+.PHONY: validate
+validate:  ## Run linters and type checkers
+	@echo "Running ruff and type checkers..."
+	. .venv/bin/activate && \
+		pip install ruff && \
+		pip install mypy && \
+		ruff format --check seedfarmer && \
+		python3 -m ruff check --fix seedfarmer && \
+		python3 -m mypy --ignore-missing-imports seedfarmer
+
+.PHONY: format
+format:  ## Format code with ruff and prettier
+	@echo "Formatting code with ruff and prettier..."
+	. .venv/bin/activate && \
+		python -m ruff format seedfarmer && \
+		python -m ruff check --fix seedfarmer && \
+		python -m ruff format test && \
+		python -m ruff check --fix test
+
+.PHONY: help
+help:  ## Show help for each of the Makefile recipes
+	@grep -E '^[a-zA-Z0-9 -]+:.*##' Makefile | sort | while read -r l; do printf "\033[1;32m$$(echo $$l | cut -f 1 -d':')\033[00m:$$(echo $$l | cut -f 2- -d'#')\n"; done
+
+.PHONY: clean
+clean:  ## Remove build artifacts and virtual environment
+	@echo "Cleaning build artifacts and virtual environment..."
+	rm -rf build/
+	rm -rf dist/
+	rm -rf *.egg-info
+	rm -rf .venv/
+	rm -rf .pytest_cache/
+	rm -rf .coverage
+	rm -rf htmlcov/
+	rm -rf .mypy_cache/
+	rm -rf .ruff_cache/
+	find . -type d -name __pycache__ -exec rm -rf {} +

--- a/README.md
+++ b/README.md
@@ -26,3 +26,28 @@ pip install seed-farmer
 ```
 
 A [project](https://seed-farmer.readthedocs.io/en/latest/project_development.html) is now necessary to begin create modules.  
+
+## Development
+
+To get started with developing you need to setup a virtual environment and install the needed python dependencies
+
+Setup virtual environment and install dependencies:
+
+```bash
+make install
+```
+
+Run unit tests
+```bash
+make test
+```
+
+Validate ruff formatting and mypy
+```bash
+make validate
+```
+
+Fix ruff formatting issues
+```bash
+make format
+```

--- a/docs/source/bootstrapping.md
+++ b/docs/source/bootstrapping.md
@@ -93,6 +93,27 @@ The qualifier post-pends a 6 chars alpha-numeric string to the deployment role a
 ## IAM Paths Prefixes for Toolchain, Target Roles, and Policies
 We have added support for the use of a IAM Paths for the toolchain role, target account deployment role(s), and policie(s). Using IAM Paths you can create groupings and design a logical separation to simplify permissions management. A common example in organizations is using Service Control Policies enforcing logical separation by team e.g. `/legal/` or `/sales/`, or project name.
 
+## Deployment Role Security Controls
+The deployment role includes explicit deny policies for certain high-risk IAM actions to improve security posture. The following IAM actions are explicitly denied regardless of any allow statements that might exist elsewhere in the policy:
+
+- `iam:CreateAccessKey` - Prevents creation of permanent access keys
+- `iam:CreateLoginProfile` - Prevents creation of console passwords
+- `iam:UpdateLoginProfile` - Prevents modification of console passwords
+- `iam:AddUserToGroup` - Prevents adding users to groups which could escalate privileges
+- `iam:AttachGroupPolicy` - Prevents attaching policies to groups
+- `iam:AttachUserPolicy` - Prevents attaching policies directly to users
+- `iam:CreatePolicyVersion` - Prevents creating new versions of IAM policies
+- `iam:DeleteGroupPolicy` - Prevents deletion of inline policies from groups
+- `iam:DeleteUserPolicy` - Prevents deletion of inline policies from users
+- `iam:DetachGroupPolicy` - Prevents detachment of policies from groups
+- `iam:DetachUserPolicy` - Prevents detachment of policies from users
+- `iam:PutGroupPolicy` - Prevents adding inline policies to groups
+- `iam:PutUserPolicy` - Prevents adding inline policies to users
+- `iam:RemoveUserFromGroup` - Prevents removing users from groups
+- `iam:SetDefaultPolicyVersion` - Prevents changing which version of a policy is active
+
+These restrictions help maintain security by preventing potential privilege escalation paths while still allowing the deployment role to perform its intended functions.
+
 A `--role-prefix` and `--policy-prefix` CLI parameters can be used if you want to provide IAM Paths to the toolchain, target roles, and project policy created by `seed-farmer`. If bootstrapped with prefixes, the same prefixes must be provided with `apply` and `destroy` CLI commands so that seedfarmer is able to locate the correct toolchain and target deployment roles. IAM Paths must begin and end with a `/`. More information in [IAM identifiers](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html).
 
 Additionally, seed-farmer creates module deployment roles at `apply`. It is possible to provide prefixes for the module deployment roles using the deployment manifest. See [manifests](manifests.md).

--- a/seedfarmer/resources/deployment_role.template
+++ b/seedfarmer/resources/deployment_role.template
@@ -158,6 +158,25 @@ Resources:
               Resource:
                 - Fn::Sub: "arn:${AWS::Partition}:codeartifact:*:${AWS::AccountId}:domain/aws-codeseeder-{{ project_name }}"
                 - Fn::Sub: "arn:${AWS::Partition}:codeartifact:*:${AWS::AccountId}:repository/aws-codeseeder-{{ project_name }}*"
+            - Action:
+              - iam:CreateAccessKey
+              - iam:CreateLoginProfile
+              - iam:UpdateLoginProfile
+              - iam:AddUserToGroup
+              - iam:AttachGroupPolicy
+              - iam:AttachUserPolicy
+              - iam:CreatePolicyVersion
+              - iam:DeleteGroupPolicy
+              - iam:DeleteUserPolicy
+              - iam:DetachGroupPolicy
+              - iam:DetachUserPolicy
+              - iam:PutGroupPolicy
+              - iam:PutUserPolicy
+              - iam:RemoveUserFromGroup
+              - iam:SetDefaultPolicyVersion
+              Effect: Deny
+              Resource: '*'
+              Sid: DeploymentIAMDeny
       RoleName: "{{ role_name }}"
       Tags:
         - Key: "SeedFarmer"

--- a/test/unit-test/test_deployment_role_security.py
+++ b/test/unit-test/test_deployment_role_security.py
@@ -1,0 +1,61 @@
+import os
+
+import pytest
+import yaml
+
+from seedfarmer import CLI_ROOT
+from seedfarmer.commands._bootstrap_commands import get_deployment_template
+
+
+@pytest.mark.commands
+@pytest.mark.commands_bootstrap
+def test_deployment_role_deny_actions():
+    """Test that the deployment role template includes the required deny actions for improved security posture."""
+    
+    # Get the deployment template using the same function the application uses
+    template = get_deployment_template(
+        toolchain_role_arn="arn:aws:iam::123456789012:role/test-role",
+        project_name="test-project",
+        role_name="test-deployment-role",
+        policy_arns=None
+    )
+    
+    # Expected deny actions that should be in the template
+    expected_deny_actions = [
+        "iam:CreateAccessKey",
+        "iam:CreateLoginProfile",
+        "iam:UpdateLoginProfile",
+        "iam:AddUserToGroup",
+        "iam:AttachGroupPolicy",
+        "iam:AttachUserPolicy",
+        "iam:CreatePolicyVersion",
+        "iam:DeleteGroupPolicy",
+        "iam:DeleteUserPolicy", 
+        "iam:DetachGroupPolicy",
+        "iam:DetachUserPolicy",
+        "iam:PutGroupPolicy",
+        "iam:PutUserPolicy",
+        "iam:RemoveUserFromGroup",
+        "iam:SetDefaultPolicyVersion"
+    ]
+    
+    # Extract the policy statements from the template
+    statements = template["Resources"]["DeploymentRole"]["Properties"]["Policies"][0]["PolicyDocument"]["Statement"]
+    
+    # Find the specific IAM deny statement
+    deny_statement = None
+    for statement in statements:
+        if statement.get("Effect") == "Deny" and statement.get("Sid") == "DeploymentIAMDeny":
+            deny_statement = statement
+            break
+    
+    # Verify the deny statement exists
+    assert deny_statement is not None, "DeploymentIAMDeny statement not found in template"
+    
+    # Verify the deny statement has the correct resource ('*')
+    assert deny_statement["Resource"] == "*", "IAM deny statement should apply to all resources ('*')"
+    
+    # Verify all expected deny actions are included
+    actions_set = set(deny_statement["Action"])
+    for action in expected_deny_actions:
+        assert action in actions_set, f"Required deny action {action} missing from template"

--- a/test/unit-test/test_deployment_role_security.py
+++ b/test/unit-test/test_deployment_role_security.py
@@ -1,9 +1,5 @@
-import os
-
 import pytest
-import yaml
 
-from seedfarmer import CLI_ROOT
 from seedfarmer.commands._bootstrap_commands import get_deployment_template
 
 
@@ -11,15 +7,15 @@ from seedfarmer.commands._bootstrap_commands import get_deployment_template
 @pytest.mark.commands_bootstrap
 def test_deployment_role_deny_actions():
     """Test that the deployment role template includes the required deny actions for improved security posture."""
-    
+
     # Get the deployment template using the same function the application uses
     template = get_deployment_template(
         toolchain_role_arn="arn:aws:iam::123456789012:role/test-role",
         project_name="test-project",
         role_name="test-deployment-role",
-        policy_arns=None
+        policy_arns=None,
     )
-    
+
     # Expected deny actions that should be in the template
     expected_deny_actions = [
         "iam:CreateAccessKey",
@@ -30,31 +26,31 @@ def test_deployment_role_deny_actions():
         "iam:AttachUserPolicy",
         "iam:CreatePolicyVersion",
         "iam:DeleteGroupPolicy",
-        "iam:DeleteUserPolicy", 
+        "iam:DeleteUserPolicy",
         "iam:DetachGroupPolicy",
         "iam:DetachUserPolicy",
         "iam:PutGroupPolicy",
         "iam:PutUserPolicy",
         "iam:RemoveUserFromGroup",
-        "iam:SetDefaultPolicyVersion"
+        "iam:SetDefaultPolicyVersion",
     ]
-    
+
     # Extract the policy statements from the template
     statements = template["Resources"]["DeploymentRole"]["Properties"]["Policies"][0]["PolicyDocument"]["Statement"]
-    
+
     # Find the specific IAM deny statement
     deny_statement = None
     for statement in statements:
         if statement.get("Effect") == "Deny" and statement.get("Sid") == "DeploymentIAMDeny":
             deny_statement = statement
             break
-    
+
     # Verify the deny statement exists
     assert deny_statement is not None, "DeploymentIAMDeny statement not found in template"
-    
+
     # Verify the deny statement has the correct resource ('*')
     assert deny_statement["Resource"] == "*", "IAM deny statement should apply to all resources ('*')"
-    
+
     # Verify all expected deny actions are included
     actions_set = set(deny_statement["Action"])
     for action in expected_deny_actions:


### PR DESCRIPTION
*Description of changes:*
Remove permission to take several actions that aren't needed for SeedFarmer deployment to improve security posture.

Add Makefile to stupid proof dev workflow.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
