### PR TITLE
fix: prime duplicate account mappings

### DIFF
--- a/seedfarmer/commands/_deployment_commands.py
+++ b/seedfarmer/commands/_deployment_commands.py
@@ -421,7 +421,7 @@ def prime_target_accounts(
 
             return [target_account_id, target_region, seedkit_stack_outputs]
 
-        params = {}
+        params: dict[tuple[str, str], Any] = {}
         for target_account_region in deployment_manifest.target_accounts_regions:
             account_id = target_account_region["account_id"]
             region = target_account_region["region"]
@@ -431,7 +431,7 @@ def prime_target_accounts(
                 target_account=account_id,
                 target_region=region,
             )
-            param_d = {
+            param_d: dict[str, Any] = {
                 "account_id": account_id,
                 "region": region,
                 "update_seedkit": update_seedkit,
@@ -455,7 +455,7 @@ def prime_target_accounts(
 
             if (account_id, region) not in params.keys():
                 params[(account_id, region)] = param_d
-            # param_d is a simple non-nested dictionary wtih string values
+            # param_d is a non-nested dictionary with string/bool values
             # that is acceptable to compare using equality operator
             elif params[(account_id, region)] == param_d:
                 _logger.info(

--- a/test/unit-test/mock_data/manifests/test-duplicate-target-account-mappings/deployment-nok.yaml
+++ b/test/unit-test/mock_data/manifests/test-duplicate-target-account-mappings/deployment-nok.yaml
@@ -1,0 +1,24 @@
+name: test-duplicate-target-account-mappings
+toolchainRegion: us-west-2
+groups:
+  - name: test
+    path: test/unit-test/mock_data/manifests/test-duplicate-target-account-mappings/test-modules.yaml
+targetAccountMappings:
+  - alias: primary
+    accountId: 123456789012
+    default: true
+    regionMappings:
+      - region: us-west-2
+        default: true
+        parametersRegional:
+          someKey: someValue
+  - alias: secondary
+    accountId: 123456789012
+    default: true
+    regionMappings:
+      - region: us-west-2
+        default: true
+        parametersRegional:
+          someKey: someValue
+        network:  # acount mappings are identical except vpc
+          vpcId: vpc-XXXXXXXXX

--- a/test/unit-test/mock_data/manifests/test-duplicate-target-account-mappings/deployment-ok.yaml
+++ b/test/unit-test/mock_data/manifests/test-duplicate-target-account-mappings/deployment-ok.yaml
@@ -1,0 +1,22 @@
+name: test-duplicate-target-account-mappings
+toolchainRegion: us-west-2
+groups:
+  - name: test
+    path: test/unit-test/mock_data/manifests/test-duplicate-target-account-mappings/test-modules.yaml
+targetAccountMappings:
+  - alias: primary
+    accountId: 123456789012
+    default: true
+    regionMappings:
+      - region: us-west-2
+        default: true
+        parametersRegional:
+          someKey: someValue
+  - alias: secondary
+    accountId: 123456789012
+    default: true
+    regionMappings:
+      - region: us-west-2
+        default: true
+        parametersRegional:
+          someKey: someValue

--- a/test/unit-test/mock_data/manifests/test-duplicate-target-account-mappings/test-modules.yaml
+++ b/test/unit-test/mock_data/manifests/test-duplicate-target-account-mappings/test-modules.yaml
@@ -1,0 +1,5 @@
+name: test-module
+path: git::https://github.com/awslabs/seed-farmer.git//test/unit-test/mock_data/modules/module-test/
+parameters:
+  - name: event_bridge_enabled
+    value: "False"

--- a/test/unit-test/test_commands_deployment.py
+++ b/test/unit-test/test_commands_deployment.py
@@ -101,6 +101,45 @@ def test_apply_with_prefix(session_manager, mocker):
 
 @pytest.mark.commands
 @pytest.mark.commands_deployment
+def test_apply_duplicate_account_mappings_ok(session_manager, mocker):
+    mocker.patch("seedfarmer.commands._deployment_commands.write_deployment_manifest", return_value=None)
+    mocker.patch("concurrent.futures.ThreadPoolExecutor.map", return_value=[])
+    mocker.patch("seedfarmer.commands._deployment_commands.create_module_deployment_role", return_value=None)
+    mocker.patch("seedfarmer.commands._deployment_commands.du.populate_module_info_index", return_value=None)
+    mocker.patch("seedfarmer.commands._deployment_commands.du.filter_deploy_destroy", return_value=None)
+    mocker.patch("seedfarmer.commands._deployment_commands.write_deployment_manifest", return_value=None)
+    mocker.patch("seedfarmer.commands._deployment_commands.du.validate_module_dependencies", return_value=None)
+    mocker.patch("seedfarmer.commands._deployment_commands.destroy_deployment", return_value=None)
+    mocker.patch("seedfarmer.commands._deployment_commands.deploy_deployment", return_value=None)
+    dc.apply(
+        deployment_manifest_path="test/unit-test/mock_data/manifests/test-duplicate-target-account-mappings/deployment-ok.yaml",
+        role_prefix="/test1/",
+        dryrun=True,
+    )
+
+
+@pytest.mark.commands
+@pytest.mark.commands_deployment
+def test_apply_duplicate_account_mappings_nok(session_manager, mocker):
+    mocker.patch("seedfarmer.commands._deployment_commands.write_deployment_manifest", return_value=None)
+    mocker.patch("concurrent.futures.ThreadPoolExecutor.map", return_value=[])
+    mocker.patch("seedfarmer.commands._deployment_commands.create_module_deployment_role", return_value=None)
+    mocker.patch("seedfarmer.commands._deployment_commands.du.populate_module_info_index", return_value=None)
+    mocker.patch("seedfarmer.commands._deployment_commands.du.filter_deploy_destroy", return_value=None)
+    mocker.patch("seedfarmer.commands._deployment_commands.write_deployment_manifest", return_value=None)
+    mocker.patch("seedfarmer.commands._deployment_commands.du.validate_module_dependencies", return_value=None)
+    mocker.patch("seedfarmer.commands._deployment_commands.destroy_deployment", return_value=None)
+    mocker.patch("seedfarmer.commands._deployment_commands.deploy_deployment", return_value=None)
+    with pytest.raises(seedfarmer.errors.InvalidManifestError):
+        dc.apply(
+            deployment_manifest_path="test/unit-test/mock_data/manifests/test-duplicate-target-account-mappings/deployment-nok.yaml",
+            role_prefix="/test1/",
+            dryrun=True,
+        )
+
+
+@pytest.mark.commands
+@pytest.mark.commands_deployment
 def test_destroy_clean(session_manager, mocker):
     mocker.patch(
         "seedfarmer.commands._deployment_commands.du.generate_deployed_manifest",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When running `seedfarmer apply` using a manifest that has multiple` targetAccountMapping`'s that point to the same account and region:
```
  - alias: primary
    accountId: 123456789012
    default: true
    regionMappings:
      - region: us-west-2
        default: true
  - alias: primaryduplicate
    accountId: 123456789012
    regionMappings:
      - region: us-west-2
        default: true
```

Both account mappings will be "bootstrapped" with [codeseeder seedkit](https://aws-codeseeder.readthedocs.io/en/latest/usage.html#usage), an S3 bucket, a managed policy stack, and a module deployment role. These resources will be created concurrently with the same naming convention that does not take into account aliases into a consideration, introducing a potential race condition.

**WARNING**: this solution skips duplicate priming of the account, if it appears more than once in the `targetAccountMapping`'s. However, for the next major version, we should explore a backward-incompatible change, to rename or prefix the resources created in the account with the account alias.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
