### PR TITLE
chore: add cli support for seedkit, correct md5 storage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ validate:  ## Run linters and type checkers
 		uv sync --frozen --inexact --no-install-project --only-dev
 		uv run ruff format --check seedfarmer --quiet && \
 		uv run ruff check seedfarmer --quiet && \
-		uv run mypy --pretty  --non-interactive --ignore-missing-imports seedfarmer
+		uv run mypy --pretty --ignore-missing-imports seedfarmer
 
 .PHONY: format
 format:  ## Format code with ruff and prettier

--- a/seedfarmer/__main__.py
+++ b/seedfarmer/__main__.py
@@ -20,7 +20,7 @@ import click
 
 import seedfarmer
 from seedfarmer import DEBUG_LOGGING_FORMAT, commands, config, enable_debug
-from seedfarmer.cli_groups import bootstrap, bundle, init, list, metadata, projectpolicy, remove, store, taint
+from seedfarmer.cli_groups import bootstrap, bundle, init, list, metadata, projectpolicy, remove, seedkit, store, taint
 from seedfarmer.output_utils import print_bolded
 from seedfarmer.utils import load_dotenv_files
 
@@ -331,5 +331,6 @@ def main() -> int:
     cli.add_command(metadata)
     cli.add_command(bundle)
     cli.add_command(taint)
+    cli.add_command(seedkit)
     cli()
     return 0

--- a/seedfarmer/cli_groups/__init__.py
+++ b/seedfarmer/cli_groups/__init__.py
@@ -19,7 +19,8 @@ from seedfarmer.cli_groups._list_group import list
 from seedfarmer.cli_groups._manage_metadata_group import metadata
 from seedfarmer.cli_groups._project_group import projectpolicy
 from seedfarmer.cli_groups._remove_group import remove
+from seedfarmer.cli_groups._seedkit_group import seedkit
 from seedfarmer.cli_groups._store_group import store
 from seedfarmer.cli_groups._taint_group import taint
 
-__all__ = ["bootstrap", "init", "list", "remove", "store", "projectpolicy", "metadata", "bundle", "taint"]
+__all__ = ["bootstrap", "bundle", "init", "list", "metadata", "projectpolicy", "remove", "seedkit", "store", "taint"]

--- a/seedfarmer/cli_groups/_seedkit_group.py
+++ b/seedfarmer/cli_groups/_seedkit_group.py
@@ -1,0 +1,157 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License").
+#    You may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+from typing import Optional, Tuple
+
+import click
+
+import seedfarmer.commands._seedkit_commands as sk_commands
+from seedfarmer.services.session_manager import SessionManager, SessionManagerLocalImpl
+
+# _logger: logging.Logger = logging.getLogger(__name__)
+
+
+@click.group(name="seedkit", help="Top Level command to support seedkits in SeedFarmer")
+def seedkit() -> None:
+    "Manage the seedkit"
+    pass
+
+
+@seedkit.command(
+    name="deploy",
+    help="""Deploy a seedkit in the specified account and region.  There can
+            be only one per seedfarmer project and is region-based.
+            """,
+)
+@click.argument(
+    "project_name",
+    type=str,
+    required=True,
+)
+@click.option("--policy-arn", required=False, type=str, multiple=True, default=[])
+@click.option(
+    "--deploy-codeartifact/--skip-codeartifact",
+    default=False,
+    help="Deploy the optional CodeArtifact Domain and Repository",
+    show_default=True,
+)
+@click.option(
+    "--profile",
+    default=None,
+    help="AWS Credentials profile to use for boto3 commands",
+    show_default=True,
+)
+@click.option(
+    "--region",
+    default=None,
+    help="AWS region to use for boto3 commands",
+    show_default=True,
+)
+@click.option(
+    "--vpc-id",
+    help="The VPC ID that the Codebuild Project resides in (only 1)",
+    required=False,
+    default=None,
+)
+@click.option(
+    "--subnet-id",
+    help="A subnet that the Codebuild Project resides in (many can be passed in)",
+    multiple=True,
+    required=False,
+    default=[],
+)
+@click.option(
+    "--sg-id",
+    help="A Securtiy Group in the VPC that the Codebuild Project can leverage (up to 5)",
+    multiple=True,
+    required=False,
+    default=[],
+)
+@click.option(
+    "--permissions-boundary-arn",
+    "-b",
+    help="ARN of a Managed Policy to set as the Permission Boundary on the CodeBuild Role",
+    required=False,
+    default=None,
+)
+@click.option(
+    "--synth/--no-synth",
+    type=bool,
+    default=False,
+    help="Synthesize seedkit template only. Do not deploy",
+    required=False,
+    show_default=True,
+)
+@click.option(
+    "--debug/--no-debug",
+    default=False,
+    help="Enable detailed logging.",
+    show_default=True,
+)
+def deploy_seedkit(
+    project_name: str,
+    policy_arn: Tuple[str, ...],
+    deploy_codeartifact: bool,
+    profile: Optional[str],
+    region: Optional[str],
+    debug: bool,
+    vpc_id: Optional[str],
+    subnet_id: Tuple[str, ...],
+    sg_id: Tuple[str, ...],
+    permissions_boundary_arn: Optional[str],
+    synth: bool,
+) -> None:
+    SessionManager.bind(SessionManagerLocalImpl())  # should ALWAYS use local profile info
+    session = SessionManager().get_or_create(region_name=region, profile=profile).toolchain_session
+    sk_commands.deploy_seedkit(
+        seedkit_name=project_name,
+        managed_policy_arns=[p for p in policy_arn],
+        deploy_codeartifact=deploy_codeartifact,
+        session=session,
+        vpc_id=vpc_id,
+        subnet_ids=[s for s in subnet_id],
+        security_group_ids=[sg for sg in sg_id],
+        permissions_boundary_arn=permissions_boundary_arn,
+        synthesize=synth,
+    )
+
+
+@seedkit.command(name="destroy")
+@click.argument(
+    "project_name",
+    type=str,
+    required=True,
+)
+@click.option(
+    "--profile",
+    default=None,
+    help="AWS Credentials profile to use for boto3 commands",
+    show_default=True,
+)
+@click.option(
+    "--region",
+    default=None,
+    help="AWS region to use for boto3 commands",
+    show_default=True,
+)
+@click.option(
+    "--debug/--no-debug",
+    default=False,
+    help="Enable detailed logging.",
+    show_default=True,
+)
+def destroy_seedkit(project_name: str, profile: Optional[str], region: Optional[str], debug: bool) -> None:
+    SessionManager.bind(SessionManagerLocalImpl())
+    session = SessionManager().get_or_create(region_name=region, profile=profile).toolchain_session
+    sk_commands.destroy_seedkit(seedkit_name=project_name, session=session)

--- a/seedfarmer/deployment/deploy_remote.py
+++ b/seedfarmer/deployment/deploy_remote.py
@@ -124,7 +124,7 @@ class DeployRemoteModule(DeployModule):
         md5_put = [
             (
                 f"echo {module_manifest.bundle_md5} | seedfarmer store md5 -d {self.mdo.deployment_manifest.name} "
-                f"-g {self.mdo.group_name} -m {module_manifest.name} -t bundle --debug ;"
+                f"-g {self.mdo.group_name} -m {module_manifest.name} -t bundle --region {region} --local"
             )
         ]
 
@@ -157,13 +157,13 @@ class DeployRemoteModule(DeployModule):
             f"if [[ -f {metadata_env_var} ]]; then export {metadata_env_var}=$(cat {metadata_env_var}); fi",
             (
                 f"echo ${metadata_env_var} | seedfarmer store moduledata "
-                f"-d {deployment_manifest.name} -g {group} -m {module_manifest.name} "
+                f"-d {deployment_manifest.name} -g {group} -m {module_manifest.name} --region {region} --local"
             ),
         ]
         store_sf_bundle = [
             (
                 f"seedfarmer bundle store -d {deployment_manifest.name} -g {group} -m {module_manifest.name} "
-                f"-o $CODEBUILD_SOURCE_REPO_URL -b {self.mdo.seedfarmer_bucket} || true"
+                f"-o $CODEBUILD_SOURCE_REPO_URL -b {self.mdo.seedfarmer_bucket} --region {region} || true"
             )
         ]
 
@@ -309,13 +309,16 @@ class DeployRemoteModule(DeployModule):
 
         env_vars = self._env_vars()
         remove_ssm = [
-            f"seedfarmer remove moduledata -d {deployment_name} -g {self.mdo.group_name} -m {module_manifest.name}"
+            (
+                f"seedfarmer remove moduledata "
+                f"-d {deployment_name} -g {self.mdo.group_name} -m {module_manifest.name} --region {region} --local"
+            )
         ]
 
         remove_sf_bundle = [
             (
                 f"seedfarmer bundle delete -d {self.mdo.deployment_manifest.name} -g {self.mdo.group_name} "
-                f"-m {module_manifest.name} -b {self.mdo.seedfarmer_bucket} || true"
+                f"-m {module_manifest.name} -b {self.mdo.seedfarmer_bucket} --region {region} || true"
             )
         ]
 

--- a/seedfarmer/mgmt/bundle_support.py
+++ b/seedfarmer/mgmt/bundle_support.py
@@ -47,7 +47,9 @@ class BundleS3Support:
             self.seedkit_key = o[1]
 
 
-def copy_bundle_to_sf(deployment: str, group: str, module: str, bucket: str, bundle_src_path: str) -> None:
+def copy_bundle_to_sf(
+    deployment: str, group: str, module: str, bucket: str, bundle_src_path: str, session: Optional[Session] = None
+) -> None:
     bundle = BundleS3Support(
         deployment=deployment, group=group, module=module, bucket=bucket, bundle_src_path=bundle_src_path
     )
@@ -57,6 +59,7 @@ def copy_bundle_to_sf(deployment: str, group: str, module: str, bucket: str, bun
             src_key=str(bundle.seedkit_key),
             dest_bucket=str(bundle.seedfarmer_bucket),
             dest_key=str(bundle.seedfarmer_key),
+            session=session,
         )
     except Exception as e:
         _logger.info("Cannot copy the bundle to S3 - %s", e)
@@ -77,10 +80,11 @@ def delete_bundle_from_sf(
     group: str,
     module: str,
     bucket: str,
+    session: Optional[Session] = None,
 ) -> None:
     bundle = BundleS3Support(deployment=deployment, group=group, module=module, bucket=bucket)
     try:
-        s3.delete_objects(bucket=str(bundle.seedfarmer_bucket), keys=[str(bundle.seedfarmer_key)])
+        s3.delete_objects(bucket=str(bundle.seedfarmer_bucket), keys=[str(bundle.seedfarmer_key)], session=session)
     except Exception as e:
         _logger.info("Cannot delete the bundle from S3 - %s", e)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- adding support for seedkit deploy / destroy from CLI 
- corrected md5 storage to SSM 
- corrected bundle storage to S3

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
