### PR TITLE
chore: deduplicate local codebuild agent

### DIFF
--- a/seedfarmer/deployment/codebuild_local.py
+++ b/seedfarmer/deployment/codebuild_local.py
@@ -15,6 +15,7 @@
 
 import os
 import subprocess
+import uuid
 from typing import Dict, Optional
 
 
@@ -60,6 +61,8 @@ def run(
         "MOUNT_SOURCE_DIRECTORY=TRUE",
         "-e",
         "INITIATOR=local_user",
+        "-e",
+        f"COMPOSE_PROJECT_NAME=agent-{str(uuid.uuid4())[:8]}",
         "-e",
         f"REPORTS={local_deploy_path}/logs",
     ]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
During local runs codebuild-local spins up docker compose with a default name (agent-resources) which causes a race condition when running multiple containers. Subsequent containers kill and re-start the agent. We can override compose project name for the agent to allow parallel runs. 

WARNING: the outputs of the containers are currently printed to the console and "smushed" together.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
