### PR TITLE
feat: add cfn params in place of jinja param injection

### DIFF
--- a/seedfarmer/commands/_cfn_seedkit.py
+++ b/seedfarmer/commands/_cfn_seedkit.py
@@ -12,17 +12,12 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-import json
 import logging
 import os
-import random
-import string
 import sys
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 import yaml
-from boto3 import Session
-from jinja2 import Template
 
 from seedfarmer import config
 from seedfarmer.utils import create_output_dir
@@ -34,20 +29,11 @@ _logger: logging.Logger = logging.getLogger(__name__)
 
 
 def synth(
-    seedkit_name: str,
     *,
-    deploy_id: Optional[str] = None,
-    managed_policy_arns: Optional[List[str]] = None,
-    deploy_codeartifact: bool = False,
-    session: Optional[Session] = None,
-    vpc_id: Optional[str] = None,
-    subnet_ids: Optional[List[str]] = None,
-    security_group_ids: Optional[List[str]] = None,
-    permissions_boundary_arn: Optional[str] = None,
+    deploy_id: str,
     synthesize: bool = False,
     **kwargs: Dict[str, Any],
 ) -> Optional[str]:
-    deploy_id = deploy_id if deploy_id else "".join(random.choice(string.ascii_lowercase) for i in range(6))
     out_dir = create_output_dir(f"seedkit-{deploy_id}")
     output_filename = os.path.join(out_dir, config.SEEDKIT_YAML_FILENAME)
     kwargs = {} if kwargs is None else kwargs
@@ -55,44 +41,14 @@ def synth(
     _logger.debug("Reading %s", config.SEEDKIT_TEMPLATE_PATH)
 
     with open(config.SEEDKIT_TEMPLATE_PATH) as f:
-        input_template = yaml.safe_load(f)
+        template = yaml.safe_load(f)
 
-    if managed_policy_arns:
-        input_template["Resources"]["CodeBuildRole"]["Properties"]["ManagedPolicyArns"] += managed_policy_arns
-
-    if vpc_id and subnet_ids and security_group_ids:
-        vpcConfig = {"VpcId": vpc_id, "SecurityGroupIds": security_group_ids, "Subnets": subnet_ids}
-        input_template["Resources"]["CodeBuildProject"]["Properties"]["VpcConfig"] = vpcConfig
-
-    if not deploy_codeartifact:
-        del input_template["Resources"]["CodeArtifactDomain"]
-        del input_template["Resources"]["CodeArtifactRepository"]
-        del input_template["Outputs"]["CodeArtifactDomain"]
-        del input_template["Outputs"]["CodeArtifactRepository"]
-
-    if permissions_boundary_arn:
-        input_template["Resources"]["CodeBuildRole"]["Properties"]["PermissionsBoundary"] = permissions_boundary_arn
-
-    role_prefix = kwargs.get("role_prefix", "/")
-    policy_prefix = kwargs.get("policy_prefix", "/")
-
-    template = Template(json.dumps(input_template))
-    t = template.render(
-        {
-            "seedkit_name": seedkit_name,
-            "deploy_id": deploy_id,
-            "role_prefix": role_prefix,
-            "policy_prefix": policy_prefix,
-        }
-    )
-
-    final_template = dict(json.loads(t))
     if not synthesize:
         _logger.debug("Writing %s", output_filename)
         os.makedirs(os.path.dirname(output_filename), exist_ok=True)
         with open(output_filename, "w") as file:
-            file.write(yaml.dump(final_template))
+            file.write(yaml.dump(template))
         return output_filename
     else:
-        sys.stdout.write(yaml.dump(final_template))
+        sys.stdout.write(yaml.dump(template))
         return None

--- a/seedfarmer/resources/deployment_role.template
+++ b/seedfarmer/resources/deployment_role.template
@@ -1,9 +1,56 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: AWS CloudFormation for the SeedFarmer Deployment Role
+
+Parameters:
+  ProjectName:
+    Type: String
+    Description: Name of the project
+  RoleName:
+    Type: String
+    Description: Name of the role to create
+  RolePrefix:
+    Type: String
+    Description: Prefix for the role path
+    Default: "/"
+  PolicyPrefix:
+    Type: String
+    Description: Prefix for the policy path
+    Default: "/"
+  ToolchainRoleArn:
+    Type: String
+    Description: ARN of the toolchain role
+  SeedFarmerVersion:
+    Type: String
+    Description: Version of SeedFarmer
+  ManagedPolicyArns:
+    Type: CommaDelimitedList
+    Description: A comma-delimited list of managed policies for the role
+    Default: ""
+  PermissionsBoundaryArn:
+    Type: String
+    Description: Permission Boundary to set on the role
+    Default: ""
+
 Outputs:
   DeploymentRoleName:
     Value:
       Ref: DeploymentRole
+
+
+Conditions:
+  HasPermissionsBoundary:
+    Fn::Not:
+      - Fn::Equals:
+          - Ref: PermissionsBoundaryArn
+          - ""
+  HasManagedPolicyArns:
+    Fn::Not:
+      - Fn::Equals:
+          - Fn::Join:
+              - ","
+              - Ref: ManagedPolicyArns
+          - ""
+
 Resources:
   DeploymentRole:
     Properties:
@@ -13,8 +60,10 @@ Resources:
         -   Action: sts:AssumeRole
             Effect: Allow
             Principal:
-                AWS: "{{ toolchain_role_arn }}"
-      Path: "{{ role_prefix }}"
+                AWS: 
+                  Ref: ToolchainRoleArn
+      Path: 
+        Ref: RolePrefix
       Policies:
         - PolicyName: InlineToolchain
           PolicyDocument:
@@ -33,7 +82,7 @@ Resources:
               - kms:Create*
               Effect: Allow
               Resource:
-                - Fn::Sub: "arn:${AWS::Partition}:kms:*:${AWS::AccountId}:alias/codeseeder-{{ project_name }}-*"
+                - Fn::Sub: "arn:${AWS::Partition}:kms:*:${AWS::AccountId}:alias/codeseeder-${ProjectName}-*"
               Sid: DeploymentKMSAlias
             - Action:
               - kms:ListKeys
@@ -64,14 +113,14 @@ Resources:
               - iam:List*
               Effect: Allow
               Resource:
-                - Fn::Sub: "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/{{ project_name }}-*"
-                - Fn::Sub: "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/codeseeder-{{ project_name }}-*"
-                - Fn::Sub: "arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/{{ project_name }}-*"
-                - Fn::Sub: "arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/codeseeder-{{ project_name }}-*"
-                - Fn::Sub: "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/*/{{ project_name }}-*"
-                - Fn::Sub: "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/*/codeseeder-{{ project_name }}-*"
-                - Fn::Sub: "arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/*/{{ project_name }}-*"
-                - Fn::Sub: "arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/*/codeseeder-{{ project_name }}-*"
+                - Fn::Sub: "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${ProjectName}-*"
+                - Fn::Sub: "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/codeseeder-${ProjectName}-*"
+                - Fn::Sub: "arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/${ProjectName}-*"
+                - Fn::Sub: "arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/codeseeder-${ProjectName}-*"
+                - Fn::Sub: "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/*/${ProjectName}-*"
+                - Fn::Sub: "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/*/codeseeder-${ProjectName}-*"
+                - Fn::Sub: "arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/*/${ProjectName}-*"
+                - Fn::Sub: "arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/*/codeseeder-${ProjectName}-*"
               Sid: DeploymentIAM
             - Action:
               - codebuild:Update*
@@ -81,7 +130,7 @@ Resources:
               - codebuild:StartBuild
               Effect: Allow
               Resource:
-                Fn::Sub: "arn:${AWS::Partition}:codebuild:*:${AWS::AccountId}:project/codeseeder-{{ project_name }}*"
+                Fn::Sub: "arn:${AWS::Partition}:codebuild:*:${AWS::AccountId}:project/codeseeder-${ProjectName}*"
               Sid: DeploymentCodeBuild
             - Action:
               - iam:ListPolicies
@@ -97,9 +146,9 @@ Resources:
               - cloudformation:*
               Effect: Allow
               Resource:
-                - Fn::Sub: "arn:${AWS::Partition}:cloudformation:*:${AWS::AccountId}:stack/{{ project_name }}-*"
-                - Fn::Sub: "arn:${AWS::Partition}:cloudformation:*:${AWS::AccountId}:stack/aws-codeseeder-{{ project_name }}/*"
-                - Fn::Sub: "arn:${AWS::Partition}:cloudformation:*:${AWS::AccountId}:stack/seedfarmer-{{ project_name }}/*"
+                - Fn::Sub: "arn:${AWS::Partition}:cloudformation:*:${AWS::AccountId}:stack/${ProjectName}-*"
+                - Fn::Sub: "arn:${AWS::Partition}:cloudformation:*:${AWS::AccountId}:stack/aws-codeseeder-${ProjectName}/*"
+                - Fn::Sub: "arn:${AWS::Partition}:cloudformation:*:${AWS::AccountId}:stack/seedfarmer-${ProjectName}/*"
             - Action:
               - s3:Delete*
               - s3:Put*
@@ -109,10 +158,10 @@ Resources:
               - s3:List*
               Effect: Allow
               Resource:
-              - Fn::Sub: "arn:${AWS::Partition}:s3:::codeseeder-{{ project_name }}*"
-              - Fn::Sub: "arn:${AWS::Partition}:s3:::codeseeder-{{ project_name }}*/*"
-              - Fn::Sub: "arn:${AWS::Partition}:s3:::seedfarmer-{{ project_name }}*"
-              - Fn::Sub: "arn:${AWS::Partition}:s3:::seedfarmer-{{ project_name }}*/*"              
+              - Fn::Sub: "arn:${AWS::Partition}:s3:::codeseeder-${ProjectName}*"
+              - Fn::Sub: "arn:${AWS::Partition}:s3:::codeseeder-${ProjectName}*/*"
+              - Fn::Sub: "arn:${AWS::Partition}:s3:::seedfarmer-${ProjectName}*"
+              - Fn::Sub: "arn:${AWS::Partition}:s3:::seedfarmer-${ProjectName}*/*"              
               Sid: DeploymentS3
             - Action:
               - sts:AssumeRole
@@ -120,8 +169,8 @@ Resources:
               - sts:GetSessionToken
               Effect: Allow
               Resource:
-              - Fn::Sub: "arn:${AWS::Partition}:iam::*:role/{{ project_name }}-*"
-              - Fn::Sub: "arn:${AWS::Partition}:iam::*:role/*/{{ project_name }}-*"
+              - Fn::Sub: "arn:${AWS::Partition}:iam::*:role/${ProjectName}-*"
+              - Fn::Sub: "arn:${AWS::Partition}:iam::*:role/*/${ProjectName}-*"
               Sid: DeploymentSTS
             - Action:
               - ssm:Put*
@@ -132,7 +181,7 @@ Resources:
               - ssm:Get*
               Effect: Allow
               Resource:
-                Fn::Sub: "arn:${AWS::Partition}:ssm:*:${AWS::AccountId}:parameter/{{ project_name }}/*"
+                Fn::Sub: "arn:${AWS::Partition}:ssm:*:${AWS::AccountId}:parameter/${ProjectName}/*"
             - Effect: Allow
               Action:
               - logs:CreateLogStream
@@ -143,21 +192,21 @@ Resources:
               - logs:GetQueryResults
               - logs:DescribeLogStreams
               Resource:
-                Fn::Sub: "arn:${AWS::Partition}:logs:*:${AWS::AccountId}:log-group:/aws/codebuild/codeseeder-{{ project_name }}*"
+                Fn::Sub: "arn:${AWS::Partition}:logs:*:${AWS::AccountId}:log-group:/aws/codebuild/codeseeder-${ProjectName}*"
             - Action:
               - cloudformation:Create*
               - cloudformation:Execute*
               - cloudformation:DeleteStack
               Effect: Allow
               Resource:
-                - Fn::Sub: "arn:${AWS::Partition}:cloudformation:*:${AWS::AccountId}:stack/aws-codeseeder-{{ project_name }}*/*"
-                - Fn::Sub: "arn:${AWS::Partition}:cloudformation:*:${AWS::AccountId}:stack/seedfarmer-{{ project_name }}*/*" 
+                - Fn::Sub: "arn:${AWS::Partition}:cloudformation:*:${AWS::AccountId}:stack/aws-codeseeder-${ProjectName}*/*"
+                - Fn::Sub: "arn:${AWS::Partition}:cloudformation:*:${AWS::AccountId}:stack/seedfarmer-${ProjectName}*/*" 
             - Action:
               - codeartifact:*
               Effect: Allow
               Resource:
-                - Fn::Sub: "arn:${AWS::Partition}:codeartifact:*:${AWS::AccountId}:domain/aws-codeseeder-{{ project_name }}"
-                - Fn::Sub: "arn:${AWS::Partition}:codeartifact:*:${AWS::AccountId}:repository/aws-codeseeder-{{ project_name }}*"
+                - Fn::Sub: "arn:${AWS::Partition}:codeartifact:*:${AWS::AccountId}:domain/aws-codeseeder-${ProjectName}"
+                - Fn::Sub: "arn:${AWS::Partition}:codeartifact:*:${AWS::AccountId}:repository/aws-codeseeder-${ProjectName}*"
             - Action:
               - iam:CreateAccessKey
               - iam:CreateLoginProfile
@@ -177,8 +226,20 @@ Resources:
               Effect: Deny
               Resource: '*'
               Sid: DeploymentIAMDeny
-      RoleName: "{{ role_name }}"
+      ManagedPolicyArns:
+        Fn::If:
+          - HasManagedPolicyArns
+          - Ref: ManagedPolicyArns
+          - Ref: "AWS::NoValue"
+      PermissionsBoundary:
+        Fn::If:
+          - HasPermissionsBoundary
+          - Ref: PermissionsBoundaryArn
+          - Ref: "AWS::NoValue"
+      RoleName: 
+        Ref: RoleName
       Tags:
         - Key: "SeedFarmer"
-          Value: "{{ seedfarmer_version }}"
+          Value: 
+            Ref: SeedFarmerVersion
     Type: AWS::IAM::Role

--- a/seedfarmer/resources/seedkit.template
+++ b/seedfarmer/resources/seedkit.template
@@ -1,19 +1,98 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: |
-  AWS CodeSeeder - codeseeder-{{ seedkit_name }}
+  AWS CodeSeeder - Seedkit Resources
 Parameters:
   BuildImage:
     Type: String
     Default: aws/codebuild/amazonlinux2-x86_64-standard:5.0
+  SeedkitName:
+    Type: String
+    Description: Name of the seedkit
+  DeployId:
+    Type: String
+    Description: Unique deployment identifier
+  RolePrefix:
+    Type: String
+    Description: Prefix for IAM roles
+    Default: "/"
+  PolicyPrefix:
+    Type: String
+    Description: Prefix for IAM policies
+    Default: "/"
+  ManagedPolicyArns:
+    Type: CommaDelimitedList
+    Description: A comma-delimited list of managed policies for the CodeBuild project role
+    Default: ""
+  VpcId:
+    Type: String
+    Description: The VPC ID to use for CodeBuild
+    Default: ""
+  SecurityGroupIds:
+    Type: CommaDelimitedList
+    Description: A comma-delimited list of security group IDs to use for CodeBuild
+    Default: ""
+  SubnetIds:
+    Type: CommaDelimitedList
+    Description: A comma-delimited list of subnets to use for CodeBuild
+    Default: ""
+  DeployCodeArtifact:
+    Type: String
+    Description: Deploy CodeArtifact Domain and Repository for use by SeedFarmer and its libraries
+    Default: "false"
+    AllowedValues:
+      - "true"
+      - "false"
+  PermissionsBoundaryArn:
+    Type: String
+    Description: Permission Boundary to set on the role
+    Default: ""
+
+Conditions:
+  HasManagedPolicies:
+    Fn::Not:
+      - Fn::Equals:
+          - Fn::Join:
+              - ","
+              - Ref: ManagedPolicyArns
+          - ""
+  HasVpcConfig:
+    Fn::And:
+      - Fn::Not:
+          - Fn::Equals:
+              - Ref: VpcId
+              - ""
+      - Fn::Not:
+          - Fn::Equals:
+              - Fn::Join:
+                  - ","
+                  - Ref: SubnetIds
+              - ""
+      - Fn::Not:
+          - Fn::Equals:
+              - Fn::Join:
+                  - ","
+                  - Ref: SecurityGroupIds
+              - ""
+  DeployCodeArtifactEnabled:
+    Fn::Equals:
+      - Ref: DeployCodeArtifact
+      - "true"
+  HasPermissionsBoundary:
+    Fn::Not:
+      - Fn::Equals:
+          - Ref: PermissionsBoundaryArn
+          - ""
+
 Resources:
   Bucket:
     Type: AWS::S3::Bucket
     Properties:
       BucketName: 
-        Fn::Sub: codeseeder-{{ seedkit_name }}-${AWS::AccountId}-{{ deploy_id }}
+        Fn::Sub: codeseeder-${SeedkitName}-${AWS::AccountId}-${DeployId}
       Tags:
         - Key: codeseeder-seedkit-name
-          Value: codeseeder-{{ seedkit_name }}
+          Value: 
+            Fn::Sub: codeseeder-${SeedkitName}
       VersioningConfiguration:
         Status: Suspended
       PublicAccessBlockConfiguration:
@@ -66,8 +145,9 @@ Resources:
     Properties:
       Description: Managed Policy granting access to the AWS CodeSeeder resources
       ManagedPolicyName: 
-        Fn::Sub: codeseeder-{{ seedkit_name }}-${AWS::Region}-resources
-      Path: "{{ policy_prefix }}"
+        Fn::Sub: codeseeder-${SeedkitName}-${AWS::Region}-resources
+      Path: 
+        Ref: PolicyPrefix
       PolicyDocument:
         Statement:
           - Effect: Allow
@@ -84,7 +164,7 @@ Resources:
               - codebuild:StartBuild
               - codebuild:BatchGetBuilds
             Resource:
-              - Fn::Sub: arn:${AWS::Partition}:codebuild:${AWS::Region}:${AWS::AccountId}:project/codeseeder-{{ seedkit_name }}
+              - Fn::Sub: arn:${AWS::Partition}:codebuild:${AWS::Region}:${AWS::AccountId}:project/codeseeder-${SeedkitName}
           - Effect: Allow
             Action:
               - ssm:Get*
@@ -98,7 +178,7 @@ Resources:
               - ssm:DeleteParameter
               - ssm:DeleteParameters
             Resource:
-              - Fn::Sub: arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/codeseeder/{{ seedkit_name }}/*
+              - Fn::Sub: arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/codeseeder/${SeedkitName}/*
           - Effect: Allow
             Action:
               - ssm:DescribeParameters
@@ -108,7 +188,7 @@ Resources:
             Action:
               - kms:*
             Resource:
-              - Fn::Sub: arn:${AWS::Partition}:kms:${AWS::Region}:${AWS::AccountId}:alias/codeseeder-{{ seedkit_name }}*
+              - Fn::Sub: arn:${AWS::Partition}:kms:${AWS::Region}:${AWS::AccountId}:alias/codeseeder-${SeedkitName}*
               - Fn::Sub: arn:${AWS::Partition}:kms:${AWS::Region}:${AWS::AccountId}:key/*
           - Effect: Allow
             Action:
@@ -121,12 +201,12 @@ Resources:
             Action:
               - codecommit:*
             Resource:
-              - Fn::Sub: arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:codeseeder-{{ seedkit_name }}-*
+              - Fn::Sub: arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:codeseeder-${SeedkitName}-*
           - Effect: Allow
             Action:
               - secretsmanager:*
             Resource:
-              - Fn::Sub: arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:codeseeder-{{ seedkit_name }}-*
+              - Fn::Sub: arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:codeseeder-${SeedkitName}-*
               - Fn::Sub: arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:*-docker-credentials*
               - Fn::Sub: arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:*-mirror-credentials*
           - Effect: Allow
@@ -140,8 +220,8 @@ Resources:
               - codeartifact:TagResource
               - codeartifact:Associate*
             Resource:
-              - Fn::Sub: arn:${AWS::Partition}:codeartifact:${AWS::Region}:${AWS::AccountId}:domain/aws-codeseeder-{{ seedkit_name }}*
-              - Fn::Sub: arn:${AWS::Partition}:codeartifact:${AWS::Region}:${AWS::AccountId}:repository/aws-codeseeder-{{ seedkit_name }}*
+              - Fn::Sub: arn:${AWS::Partition}:codeartifact:${AWS::Region}:${AWS::AccountId}:domain/aws-codeseeder-${SeedkitName}*
+              - Fn::Sub: arn:${AWS::Partition}:codeartifact:${AWS::Region}:${AWS::AccountId}:repository/aws-codeseeder-${SeedkitName}*
           - Effect: Allow
             Action:
               - codeartifact:GetAuthorizationToken
@@ -164,8 +244,8 @@ Resources:
               - s3:DeleteObjectVersion
               - s3:DeleteBucket
             Resource:
-              - Fn::Sub: arn:${AWS::Partition}:s3:::codeseeder-{{ seedkit_name }}-${AWS::AccountId}-{{ deploy_id }}/*
-              - Fn::Sub: arn:${AWS::Partition}:s3:::codeseeder-{{ seedkit_name }}-${AWS::AccountId}-{{ deploy_id }}
+              - Fn::Sub: arn:${AWS::Partition}:s3:::codeseeder-${SeedkitName}-${AWS::AccountId}-${DeployId}/*
+              - Fn::Sub: arn:${AWS::Partition}:s3:::codeseeder-${SeedkitName}-${AWS::AccountId}-${DeployId}
           - Effect: Allow
             Action:
               - s3:GetEncryptionConfiguration
@@ -174,7 +254,7 @@ Resources:
             Action:
               - logs:*
             Resource:
-              - Fn::Sub: arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/codeseeder-{{ seedkit_name }}*
+              - Fn::Sub: arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/codeseeder-${SeedkitName}*
           - Effect: Allow
             Action:
               - cloudformation:DescribeStacks
@@ -196,9 +276,10 @@ Resources:
   CodeBuildRole:
     Type: AWS::IAM::Role
     Properties:
-      Path: "{{ role_prefix }}"
+      Path: 
+        Ref: RolePrefix
       RoleName: 
-        Fn::Sub: codeseeder-{{ seedkit_name }}-${AWS::Region}-codebuild
+        Fn::Sub: codeseeder-${SeedkitName}-${AWS::Region}-codebuild
       MaxSessionDuration: 10000
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
@@ -216,20 +297,38 @@ Resources:
               Service: cloudformation.amazonaws.com
             Action: sts:AssumeRole
       ManagedPolicyArns:
-        - Ref: SeedkitResourcesPolicy
+        Fn::If:
+          - HasManagedPolicies
+          - Fn::Split:
+              - ','
+              - Fn::Join:
+                  - ','
+                  - - Ref: SeedkitResourcesPolicy
+                    - Fn::Join:
+                        - ','
+                        - Ref: ManagedPolicyArns
+          - - Ref: SeedkitResourcesPolicy
+      PermissionsBoundary:
+        Fn::If:
+          - HasPermissionsBoundary
+          - Ref: PermissionsBoundaryArn
+          - Ref: "AWS::NoValue"
       Tags:
         - Key: codeseeder-seedkit-name
-          Value: codeseeder-{{ seedkit_name }}
+          Value: 
+            Fn::Sub: codeseeder-${SeedkitName}
 
   CodeBuildProject:
     Type: AWS::CodeBuild::Project
     DependsOn: 
       - SeedkitResourcesPolicy
     Properties:
-      Name: codeseeder-{{ seedkit_name }}
+      Name: 
+        Fn::Sub: codeseeder-${SeedkitName}
       Tags:
         - Key: codeseeder-seedkit-name
-          Value: codeseeder-{{ seedkit_name }}
+          Value: 
+            Fn::Sub: codeseeder-${SeedkitName}
       Description: Legacy AWS CodeSeeder CLI backend.
       ServiceRole: 
         Fn::GetAtt: 
@@ -237,6 +336,16 @@ Resources:
           - Arn
       Artifacts:
         Type: NO_ARTIFACTS
+      VpcConfig:
+        Fn::If:
+          - HasVpcConfig
+          - VpcId:
+              Ref: VpcId
+            SecurityGroupIds:
+              Ref: SecurityGroupIds
+            Subnets:
+              Ref: SubnetIds
+          - Ref: "AWS::NoValue"
       Environment:
         Type: LINUX_CONTAINER
         ComputeType: BUILD_GENERAL1_SMALL
@@ -247,7 +356,8 @@ Resources:
             Value:
               Ref: AWS::AccountId
           - Name: AWS_CODESEEDER_NAME
-            Value: "{{ seedkit_name }}"
+            Value: 
+              Ref: SeedkitName
           - Name: AWS_CODESEEDER_DOCKER_SECRET
             Value: "NONE"
           - Name: AWS_CODESEEDER_PYPI_MIRROR_SECRET
@@ -279,14 +389,16 @@ Resources:
       LogsConfig:
         CloudWatchLogs:
           Status: ENABLED
-          GroupName: /aws/codebuild/codeseeder-{{ seedkit_name }}
+          GroupName: 
+            Fn::Sub: /aws/codebuild/codeseeder-${SeedkitName}
         S3Logs:
           Status: DISABLED
 
   KmsKeyAlias:
     Type: AWS::KMS::Alias
     Properties:
-      AliasName: alias/codeseeder-{{ seedkit_name }}-{{ deploy_id }}
+      AliasName: 
+        Fn::Sub: alias/codeseeder-${SeedkitName}-${DeployId}
       TargetKeyId:
         Ref: KmsKey
 
@@ -295,11 +407,14 @@ Resources:
     Properties:
       Tags:
         - Key: codeseeder-seedkit-name
-          Value: codeseeder-{{ seedkit_name }}
-      Description: AWS CodeSeeder Key for {{ seedkit_name }}.
+          Value: 
+            Fn::Sub: codeseeder-${SeedkitName}
+      Description: 
+        Fn::Sub: AWS CodeSeeder Key for ${SeedkitName}.
       KeyPolicy:
         Version: '2012-10-17'
-        Id: codeseeder-{{ seedkit_name }}
+        Id: 
+          Fn::Sub: codeseeder-${SeedkitName}
         Statement:
           - Sid: Enable IAM User Permissions
             Effect: Allow
@@ -330,14 +445,18 @@ Resources:
 
   CodeArtifactDomain:
     Type: AWS::CodeArtifact::Domain
+    Condition: DeployCodeArtifactEnabled
     Properties:
-      DomainName: aws-codeseeder-{{ seedkit_name }}
+      DomainName: 
+        Fn::Sub: aws-codeseeder-${SeedkitName}
       Tags:
         - Key: codeseeder-seedkit-name
-          Value: codeseeder-{{ seedkit_name }}
+          Value: 
+            Fn::Sub: codeseeder-${SeedkitName}
 
   CodeArtifactRepository:
     Type: AWS::CodeArtifact::Repository
+    Condition: DeployCodeArtifactEnabled
     Properties:
       DomainName:
         Fn::GetAtt:
@@ -348,20 +467,23 @@ Resources:
         - "public:pypi"
       Tags:
         - Key: codeseeder-seedkit-name
-          Value: codeseeder-{{ seedkit_name }}
-
+          Value: 
+            Fn::Sub: codeseeder-${SeedkitName}
 
 Outputs:
   DeployId:
-    Value: '{{ deploy_id }}'
+    Value: 
+      Ref: DeployId
     Export:
-      Name: codeseeder-{{ seedkit_name }}-deploy-id
+      Name: 
+        Fn::Sub: codeseeder-${SeedkitName}-deploy-id
 
   Bucket:
     Value: 
       Ref: Bucket
     Export:
-      Name: codeseeder-{{ seedkit_name }}-bucket
+      Name: 
+        Fn::Sub: codeseeder-${SeedkitName}-bucket
 
   KmsKeyArn:
     Value:
@@ -369,19 +491,22 @@ Outputs:
         - KmsKey
         - Arn
     Export:
-      Name: codeseeder-{{ seedkit_name }}-kms-arn
+      Name: 
+        Fn::Sub: codeseeder-${SeedkitName}-kms-arn
 
   SeedkitResourcesPolicyArn:
     Value: 
       Ref: SeedkitResourcesPolicy
     Export:
-      Name: codeseeder-{{ seedkit_name }}-resources-policy
+      Name: 
+        Fn::Sub: codeseeder-${SeedkitName}-resources-policy
 
   CodeBuildRole:
     Value: 
       Ref: CodeBuildRole
     Export:
-      Name: codeseeder-{{ seedkit_name }}-codebuild-role
+      Name: 
+        Fn::Sub: codeseeder-${SeedkitName}-codebuild-role
 
   CodeBuildRoleArn:
     Value:
@@ -389,13 +514,15 @@ Outputs:
         - CodeBuildRole
         - Arn
     Export:
-      Name: codeseeder-{{ seedkit_name }}-codebuild-role-arn
+      Name: 
+        Fn::Sub: codeseeder-${SeedkitName}-codebuild-role-arn
 
   CodeBuildProject:
     Value: 
       Ref: CodeBuildProject
     Export:
-      Name: codeseeder-{{ seedkit_name }}-codebuild-project
+      Name: 
+        Fn::Sub: codeseeder-${SeedkitName}-codebuild-project
 
   CodeBuildProjectArn:
     Value:
@@ -403,26 +530,32 @@ Outputs:
         - CodeBuildProject
         - Arn
     Export:
-      Name: codeseeder-{{ seedkit_name }}-codebuild-project-arn
+      Name: 
+        Fn::Sub: codeseeder-${SeedkitName}-codebuild-project-arn
   
   CodeBuildProjectBuildImage:
     Value: 
       Ref: BuildImage
     Export:
-      Name: codeseeder-{{ seedkit_name }}-codebuild-project-build-image
+      Name: 
+        Fn::Sub: codeseeder-${SeedkitName}-codebuild-project-build-image
 
   CodeArtifactDomain:
+    Condition: DeployCodeArtifactEnabled
     Value:
       Fn::GetAtt:
         - CodeArtifactDomain
         - Name
     Export:
-      Name: codeseeder-{{ seedkit_name }}-codeartifact-domain
+      Name: 
+        Fn::Sub: codeseeder-${SeedkitName}-codeartifact-domain
 
   CodeArtifactRepository:
+    Condition: DeployCodeArtifactEnabled
     Value:
       Fn::GetAtt:
         - CodeArtifactRepository
         - Name
     Export:
-      Name: codeseeder-{{ seedkit_name }}-codeartifact-repository
+      Name: 
+        Fn::Sub: codeseeder-${SeedkitName}-codeartifact-repository

--- a/seedfarmer/resources/toolchain_role.template
+++ b/seedfarmer/resources/toolchain_role.template
@@ -1,9 +1,48 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: AWS CloudFormation for the SeedFarmer Toolchain Role
+
+Parameters:
+  ProjectName:
+    Type: String
+    Description: Name of the project
+  RoleName:
+    Type: String
+    Description: Name of the role to create
+  RolePrefix:
+    Type: String
+    Description: Prefix for the role path
+    Default: "/"
+  SeedFarmerVersion:
+    Type: String
+    Description: Version of SeedFarmer
+  PrincipalArns:
+    Type: CommaDelimitedList
+    Description: A comma-delimited list of trusted principals for the role
+    Default: ""
+  PermissionsBoundaryArn:
+    Type: String
+    Description: Permission Boundary to set on the role
+    Default: ""
 Outputs:
   ToolchainRoleName:
     Value:
       Ref: ToolchainRole
+
+Conditions:
+  HasPermissionsBoundary: 
+    Fn::Not:
+      - Fn::Equals:
+          - Ref: PermissionsBoundaryArn
+          - ""
+  HasPrincipals:
+    Fn::Not:
+      - Fn::Equals:
+          - Fn::Join:
+              - ","
+              - Ref: PrincipalArns
+          - ""
+
+
 Resources:
   ToolchainRole:
     Properties:
@@ -13,8 +52,13 @@ Resources:
         -   Action: sts:AssumeRole
             Effect: Allow
             Principal:
-                AWS: []
-      Path: "{{ role_prefix }}"
+                AWS:
+                  Fn::If:
+                    - HasPrincipals
+                    - Ref: PrincipalArns
+                    - Ref: "AWS::NoValue"
+      Path: 
+        Ref: RolePrefix
       Policies:
         - PolicyName: InlineToolchain
           PolicyDocument:
@@ -25,8 +69,8 @@ Resources:
               - sts:GetSessionToken
               Effect: Allow
               Resource:
-                - Fn::Sub: "arn:${AWS::Partition}:iam::*:role/seedfarmer-{{ project_name }}*"
-                - Fn::Sub: "arn:${AWS::Partition}:iam::*:role/*/seedfarmer-{{ project_name }}*"
+                - Fn::Sub: "arn:${AWS::Partition}:iam::*:role/seedfarmer-${ProjectName}*"
+                - Fn::Sub: "arn:${AWS::Partition}:iam::*:role/*/seedfarmer-${ProjectName}*"
               Sid: ToolChainSTS
             - Action:
               - ssm:Put*
@@ -37,7 +81,7 @@ Resources:
               - ssm:Get*
               Effect: Allow
               Resource:
-                Fn::Sub: "arn:${AWS::Partition}:ssm:*:${AWS::AccountId}:parameter/{{ project_name }}/*"
+                Fn::Sub: "arn:${AWS::Partition}:ssm:*:${AWS::AccountId}:parameter/${ProjectName}/*"
               Sid: ToolChainSSM
             - Action:
               - ssm:Describe*
@@ -56,9 +100,16 @@ Resources:
               Action:
                 - s3:GetObject*
               Resource:
-                - Fn::Sub: "arn:${AWS::Partition}:s3:::{{ project_name }}-*/*"
-      RoleName: "{{ role_name }}"
+                - Fn::Sub: "arn:${AWS::Partition}:s3:::${ProjectName}-*/*"
+      PermissionsBoundary:
+        Fn::If:
+          - HasPermissionsBoundary
+          - Ref: PermissionsBoundaryArn
+          - Ref: "AWS::NoValue"
+      RoleName: 
+        Ref: RoleName
       Tags:
         - Key: "SeedFarmer"
-          Value: "{{ seedfarmer_version }}"
+          Value: 
+            Ref: SeedFarmerVersion
     Type: AWS::IAM::Role

--- a/test/unit-test/test_cfn_seedkit.py
+++ b/test/unit-test/test_cfn_seedkit.py
@@ -1,0 +1,97 @@
+import os
+
+import pytest
+import yaml
+
+from seedfarmer import config
+from seedfarmer.commands import _cfn_seedkit as cfn_seedkit
+
+
+@pytest.mark.commands
+@pytest.mark.commands_seedkit
+def test_synth_creates_file(mocker):
+    """Test that synth creates a file with the expected content."""
+    # Mock the template file
+    template_content = {"Resources": {"TestResource": {"Type": "AWS::S3::Bucket"}}}
+
+    # Mock open to return the template content
+    mock_open = mocker.patch("builtins.open", mocker.mock_open(read_data=yaml.dump(template_content)))
+
+    # Mock yaml.safe_load to return the template content
+    mocker.patch("yaml.safe_load", return_value=template_content)
+
+    # Define the expected output directory
+    output_dir = "/Users/noahpaig/Desktop/seedfarmer/seed-farmer/.seedfarmer.out/seedkit-test123"
+
+    # Mock create_output_dir to return our expected path
+    mocker.patch("seedfarmer.utils.create_output_dir", return_value=output_dir)
+
+    # Call the function
+    result = cfn_seedkit.synth(deploy_id="test123")
+
+    # Verify the result is the expected filename
+    expected_filename = os.path.join(output_dir, config.SEEDKIT_YAML_FILENAME)
+    assert result == expected_filename
+
+    # Verify open was called with the correct paths
+    mock_open.assert_any_call(config.SEEDKIT_TEMPLATE_PATH)
+    mock_open.assert_any_call(expected_filename, "w")
+
+
+@pytest.mark.commands
+@pytest.mark.commands_seedkit
+def test_synth_synthesize_only(mocker):
+    """Test that synth with synthesize=True outputs to stdout and returns None."""
+    # Mock the template file
+    template_content = {"Resources": {"TestResource": {"Type": "AWS::S3::Bucket"}}}
+
+    # Mock open to return the template content
+    mock_open = mocker.patch("builtins.open", mocker.mock_open(read_data=yaml.dump(template_content)))
+
+    # Mock yaml.safe_load to return the template content
+    mocker.patch("yaml.safe_load", return_value=template_content)
+
+    # Mock yaml.dump to return a string
+    mocker.patch("yaml.dump", return_value="yaml content")
+
+    # Mock sys.stdout.write
+    mock_stdout = mocker.patch("sys.stdout.write")
+
+    # Call the function
+    result = cfn_seedkit.synth(deploy_id="test123", synthesize=True)
+
+    # Verify the result is None
+    assert result is None
+
+    # Verify stdout.write was called with the template content
+    mock_stdout.assert_called_once_with("yaml content")
+
+    # Verify open was only called once (for reading the template)
+    assert mock_open.call_count == 1
+
+
+@pytest.mark.commands
+@pytest.mark.commands_seedkit
+def test_synth_with_kwargs(mocker):
+    """Test that synth accepts and ignores additional kwargs."""
+    # Mock the template file
+    template_content = {"Resources": {"TestResource": {"Type": "AWS::S3::Bucket"}}}
+
+    # Mock open to return the template content
+    mocker.patch("builtins.open", mocker.mock_open(read_data=yaml.dump(template_content)))
+
+    # Mock yaml.safe_load to return the template content
+    mocker.patch("yaml.safe_load", return_value=template_content)
+
+    # Define the expected output directory
+    output_dir = "/Users/noahpaig/Desktop/seedfarmer/seed-farmer/.seedfarmer.out/seedkit-test123"
+
+    # Mock create_output_dir to return our expected path
+    mocker.patch("seedfarmer.utils.create_output_dir", return_value=output_dir)
+
+    # Call the function with additional kwargs
+    result = cfn_seedkit.synth(deploy_id="test123", extra_param="value", another_param=123)
+
+    # Verify the result is the expected filename
+    expected_filename = os.path.join(output_dir, config.SEEDKIT_YAML_FILENAME)
+    assert result == expected_filename

--- a/test/unit-test/test_commands_bootstrap.py
+++ b/test/unit-test/test_commands_bootstrap.py
@@ -2,6 +2,7 @@ import os
 
 import boto3
 import pytest
+from botocore.exceptions import WaiterError
 from moto import mock_aws
 
 import seedfarmer
@@ -67,16 +68,81 @@ def session_manager(sts_client):
 
 @pytest.mark.commands
 @pytest.mark.commands_bootstrap
+def test_get_template_invalid_yaml(mocker):
+    """Test that get_template raises TypeError when YAML is not a dictionary."""
+    # Mock open to return a non-dictionary YAML
+    mocker.patch("builtins.open", mocker.mock_open(read_data="- item1\n- item2"))
+
+    # Mock yaml.safe_load to return a list instead of a dict
+    mocker.patch("yaml.safe_load", return_value=["item1", "item2"])
+
+    # Verify that TypeError is raised
+    with pytest.raises(TypeError, match="Expected dictionary from YAML file, got list"):
+        bc.get_template("toolchain_role")
+
+
+@pytest.mark.commands
+@pytest.mark.commands_bootstrap
+def test_write_template(mocker):
+    """Test that write_template correctly outputs the template to stdout."""
+    # Mock yaml.dump
+    mock_dump = mocker.patch("yaml.dump")
+
+    # Mock print
+    mock_print = mocker.patch("builtins.print")
+
+    # Call the function
+    template = {"Resources": {"TestResource": {"Type": "AWS::S3::Bucket"}}}
+    bc.write_template(template)
+
+    # Verify yaml.dump was called with the template and sys.stdout
+    mock_dump.assert_called_once_with(template, mocker.ANY)
+
+    # Verify print was called with an empty string
+    mock_print.assert_called_once_with("")
+
+
+@pytest.mark.commands
+@pytest.mark.commands_bootstrap
 def test_deploy_template(session_manager, mocker):
     mocker.patch("seedfarmer.commands._bootstrap_commands.role_deploy_status", return_value={"RoleName": "BLAHBLAH"})
     mocker.patch("seedfarmer.commands._bootstrap_commands.cfn.deploy_template", return_value=None)
-    template = bc.get_toolchain_template(
-        project_name="myapp",
-        role_name="seedfarmer-test-toolchain-role",
-        principal_arn=["arn:aws:iam::123456789012:role/AdminRole"],
-    )
+    template = bc.get_template("toolchain_role")
+    parameters = {
+        "ProjectName": "myapp",
+        "RoleName": "seedfarmer-test-toolchain-role",
+        "PrincipalArn": "arn:aws:iam::123456789012:role/AdminRole",
+    }
 
-    bc.deploy_template(template=template, stack_name="UnitTest", session=None)
+    bc.deploy_template(template=template, stack_name="UnitTest", session=None, parameters=parameters)
+
+
+@pytest.mark.commands
+@pytest.mark.commands_bootstrap
+def test_deploy_template_waiter_error(mocker):
+    """Test that deploy_template handles WaiterError correctly."""
+    # Mock os.makedirs
+    mocker.patch("os.makedirs")
+
+    # Mock open
+    mocker.patch("builtins.open", mocker.mock_open())
+
+    # Mock yaml.dump
+    mocker.patch("yaml.dump")
+
+    # Mock cfn.deploy_template to raise WaiterError
+    mocker.patch("seedfarmer.services._cfn.deploy_template", side_effect=WaiterError("waiter_name", "reason", {}))
+
+    # Mock os.remove
+    mock_remove = mocker.patch("os.remove")
+
+    # Call the function and verify it raises WaiterError
+    template = {"Resources": {"TestResource": {"Type": "AWS::S3::Bucket"}}}
+    with pytest.raises(WaiterError):
+        bc.deploy_template(template=template, stack_name="test-stack", session=None, parameters={"Param1": "Value1"})
+
+    # Verify os.remove was called (cleanup happens in finally block)
+    mock_remove.assert_called_once()
 
 
 @pytest.mark.commands
@@ -87,13 +153,16 @@ def test_apply_deploy_logic(session_manager, mocker):
         return_value=({"RoleName": "BLAHBLAH"}, ["exists"]),
     )
     mocker.patch("seedfarmer.commands._bootstrap_commands.cfn.deploy_template", return_value=None)
-    template = bc.get_toolchain_template(
-        project_name="myapp",
-        role_name="seedfarmer-test-toolchain-role",
-        principal_arn=["arn:aws:iam::123456789012:role/AdminRole"],
-    )
+    template = bc.get_template("toolchain_role")
+    parameters = {
+        "ProjectName": "myapp",
+        "RoleName": "seedfarmer-test-toolchain-role",
+        "PrincipalArn": "arn:aws:iam::123456789012:role/AdminRole",
+    }
 
-    bc.apply_deploy_logic(template=template, role_name="toolchain-role", stack_name="toolchain-stack", session=None)
+    bc.apply_deploy_logic(
+        template=template, role_name="toolchain-role", stack_name="toolchain-stack", session=None, parameters=parameters
+    )
 
 
 @pytest.mark.commands
@@ -101,13 +170,16 @@ def test_apply_deploy_logic(session_manager, mocker):
 def test_apply_deploy_logic_role_not_exists(session_manager, mocker):
     mocker.patch("seedfarmer.commands._bootstrap_commands.role_deploy_status", return_value=(None, ["exists"]))
     mocker.patch("seedfarmer.commands._bootstrap_commands.cfn.deploy_template", return_value=None)
-    template = bc.get_toolchain_template(
-        project_name="myapp",
-        role_name="seedfarmer-test-toolchain-role",
-        principal_arn=["arn:aws:iam::123456789012:role/AdminRole"],
-    )
+    template = bc.get_template("toolchain_role")
+    parameters = {
+        "ProjectName": "myapp",
+        "RoleName": "seedfarmer-test-toolchain-role",
+        "PrincipalArn": "arn:aws:iam::123456789012:role/AdminRole",
+    }
 
-    bc.apply_deploy_logic(template=template, role_name="toolchain-role", stack_name="toolchain-stack", session=None)
+    bc.apply_deploy_logic(
+        template=template, role_name="toolchain-role", stack_name="toolchain-stack", session=None, parameters=parameters
+    )
 
 
 @pytest.mark.commands
@@ -115,13 +187,16 @@ def test_apply_deploy_logic_role_not_exists(session_manager, mocker):
 def test_apply_deploy_logic_stack_not_exists(session_manager, mocker):
     mocker.patch("seedfarmer.commands._bootstrap_commands.role_deploy_status", return_value=(None, None))
     mocker.patch("seedfarmer.commands._bootstrap_commands.cfn.deploy_template", return_value=None)
-    template = bc.get_toolchain_template(
-        project_name="myapp",
-        role_name="seedfarmer-test-toolchain-role",
-        principal_arn=["arn:aws:iam::123456789012:role/AdminRole"],
-    )
+    template = bc.get_template("toolchain_role")
+    parameters = {
+        "ProjectName": "myapp",
+        "RoleName": "seedfarmer-test-toolchain-role",
+        "PrincipalArn": "arn:aws:iam::123456789012:role/AdminRole",
+    }
 
-    bc.apply_deploy_logic(template=template, role_name="toolchain-role", stack_name="toolchain-stack", session=None)
+    bc.apply_deploy_logic(
+        template=template, role_name="toolchain-role", stack_name="toolchain-stack", session=None, parameters=parameters
+    )
 
 
 @pytest.mark.commands
@@ -231,6 +306,95 @@ def test_bootstrap_toolchain_account_with_policies(mocker, session):
         synthesize=False,
         as_target=False,
     )
+
+
+@pytest.mark.commands
+@pytest.mark.commands_bootstrap
+def test_bootstrap_toolchain_account_as_target(mocker):
+    """Test bootstrap_toolchain_account with as_target=True."""
+    # Mock apply_deploy_logic
+    mock_apply = mocker.patch("seedfarmer.commands._bootstrap_commands.apply_deploy_logic")
+
+    # Mock bootstrap_target_account
+    mock_bootstrap_target = mocker.patch("seedfarmer.commands._bootstrap_commands.bootstrap_target_account")
+
+    # Mock get_sts_identity_info
+    mocker.patch(
+        "seedfarmer.commands._bootstrap_commands.get_sts_identity_info",
+        return_value=("123456789012", "arn:aws:iam::123456789012:role/test", "aws"),
+    )
+
+    # Call the function
+    bc.bootstrap_toolchain_account(
+        project_name="test-project",
+        principal_arns=["arn:aws:iam::123456789012:role/AdminRole"],
+        permissions_boundary_arn="arn:aws:iam::123456789012:policy/boundary",
+        policy_arns=["arn:aws:iam::aws:policy/ReadOnlyAccess"],
+        qualifier="test",
+        role_prefix="/custom/",
+        policy_prefix="/custom/",
+        profile="default",
+        region_name="us-east-1",
+        synthesize=False,
+        as_target=True,
+    )
+
+    # Verify apply_deploy_logic was called
+    mock_apply.assert_called_once()
+
+    # Verify bootstrap_target_account was called with the correct parameters
+    mock_bootstrap_target.assert_called_once()
+    args, kwargs = mock_bootstrap_target.call_args
+    assert kwargs["toolchain_account_id"] == "123456789012"
+    assert kwargs["project_name"] == "test-project"
+    assert kwargs["qualifier"] == "test"
+    assert kwargs["role_prefix"] == "/custom/"
+    assert kwargs["policy_prefix"] == "/custom/"
+    assert kwargs["permissions_boundary_arn"] == "arn:aws:iam::123456789012:policy/boundary"
+    assert kwargs["profile"] == "default"
+    assert kwargs["region_name"] == "us-east-1"
+    assert kwargs["policy_arns"] == ["arn:aws:iam::aws:policy/ReadOnlyAccess"]
+
+
+@pytest.mark.commands
+@pytest.mark.commands_bootstrap
+def test_bootstrap_toolchain_account_as_target_synthesize(mocker):
+    """Test bootstrap_toolchain_account with as_target=True and synthesize=True."""
+    # Mock write_template
+    mock_write = mocker.patch("seedfarmer.commands._bootstrap_commands.write_template")
+
+    # Mock bootstrap_target_account
+    mock_bootstrap_target = mocker.patch("seedfarmer.commands._bootstrap_commands.bootstrap_target_account")
+
+    # Call the function
+    bc.bootstrap_toolchain_account(
+        project_name="test-project",
+        principal_arns=["arn:aws:iam::123456789012:role/AdminRole"],
+        permissions_boundary_arn="arn:aws:iam::123456789012:policy/boundary",
+        policy_arns=["arn:aws:iam::aws:policy/ReadOnlyAccess"],
+        qualifier="test",
+        role_prefix="/custom/",
+        policy_prefix="/custom/",
+        profile="default",
+        region_name="us-east-1",
+        synthesize=True,
+        as_target=True,
+    )
+
+    # Verify write_template was called
+    mock_write.assert_called_once()
+
+    # Verify bootstrap_target_account was called with the correct parameters
+    mock_bootstrap_target.assert_called_once()
+    args, kwargs = mock_bootstrap_target.call_args
+    assert kwargs["toolchain_account_id"] == "123456789012"
+    assert kwargs["project_name"] == "test-project"
+    assert kwargs["qualifier"] == "test"
+    assert kwargs["permissions_boundary_arn"] == "arn:aws:iam::123456789012:policy/boundary"
+    assert kwargs["policy_arns"] == ["arn:aws:iam::aws:policy/ReadOnlyAccess"]
+    assert kwargs["profile"] == "default"
+    assert kwargs["region_name"] == "us-east-1"
+    assert kwargs["synthesize"] is True
 
 
 @pytest.mark.commands

--- a/test/unit-test/test_commands_seedkit.py
+++ b/test/unit-test/test_commands_seedkit.py
@@ -1,0 +1,199 @@
+import os
+
+import pytest
+from moto import mock_aws
+
+import seedfarmer.commands._seedkit_commands as sc
+from seedfarmer.services._service_utils import boto3_client
+
+
+@pytest.fixture(scope="function")
+def aws_credentials():
+    """Mocked AWS Credentials for moto."""
+    os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+    os.environ["AWS_SECURITY_TOKEN"] = "testing"
+    os.environ["AWS_SESSION_TOKEN"] = "testing"
+    os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+    os.environ["MOTO_ACCOUNT_ID"] = "123456789012"
+
+
+@pytest.fixture(scope="function")
+def sts_client(aws_credentials):
+    with mock_aws():
+        yield boto3_client(service_name="sts", session=None)
+
+
+@pytest.mark.commands
+@pytest.mark.commands_seedkit
+def test_seedkit_deployed(mocker):
+    """Test the seedkit_deployed function."""
+    # Mock the CloudFormation stack existence check
+    mocker.patch(
+        "seedfarmer.services._cfn.does_stack_exist",
+        return_value=(True, {"Bucket": "test-bucket", "DeployId": "abc123"}),
+    )
+
+    # Call the function
+    exists, stack_name, outputs = sc.seedkit_deployed("test-seedkit")
+
+    # Verify the results
+    assert exists is True
+    assert stack_name == "aws-codeseeder-test-seedkit"
+    assert outputs == {"Bucket": "test-bucket", "DeployId": "abc123"}
+
+
+@pytest.mark.commands
+@pytest.mark.commands_seedkit
+def test_deploy_seedkit_existing(mocker):
+    """Test deploying a seedkit that already exists."""
+    # Mock the seedkit_deployed function
+    mocker.patch(
+        "seedfarmer.commands._seedkit_commands.seedkit_deployed",
+        return_value=(True, "seedkit-test-stack", {"DeployId": "abc123"}),
+    )
+
+    # Mock the synth function
+    mocker.patch("seedfarmer.commands._cfn_seedkit.synth", return_value="/tmp/template.yaml")
+
+    # Mock the deploy_template function
+    mock_deploy = mocker.patch("seedfarmer.services._cfn.deploy_template")
+
+    # Call the function
+    sc.deploy_seedkit(
+        seedkit_name="test-seedkit",
+        managed_policy_arns=["arn:aws:iam::aws:policy/ReadOnlyAccess"],
+        deploy_codeartifact=True,
+    )
+
+    # Verify the deploy_template was called with correct parameters
+    mock_deploy.assert_called_once()
+    args, kwargs = mock_deploy.call_args
+    assert kwargs["stack_name"] == "seedkit-test-stack"
+    assert kwargs["filename"] == "/tmp/template.yaml"
+    assert kwargs["seedkit_tag"] == "codeseeder-test-seedkit"
+
+    # Verify parameters dictionary contains expected values
+    parameters = kwargs["parameters"]
+    assert parameters["SeedkitName"] == "test-seedkit"
+    assert parameters["DeployId"] == "abc123"
+    assert parameters["DeployCodeArtifact"] == "true"
+    assert parameters["ManagedPolicyArns"] == "arn:aws:iam::aws:policy/ReadOnlyAccess"
+
+
+@pytest.mark.commands
+@pytest.mark.commands_seedkit
+def test_deploy_seedkit_new(mocker):
+    """Test deploying a new seedkit."""
+    # Mock the seedkit_deployed function
+    mocker.patch(
+        "seedfarmer.commands._seedkit_commands.seedkit_deployed", return_value=(False, "seedkit-test-stack", {})
+    )
+
+    # Mock the synth function
+    mocker.patch("seedfarmer.commands._cfn_seedkit.synth", return_value="/tmp/template.yaml")
+
+    # Mock random.choice to return predictable values
+    mocker.patch("random.choice", side_effect=lambda x: x[0])
+
+    # Mock the deploy_template function
+    mock_deploy = mocker.patch("seedfarmer.services._cfn.deploy_template")
+
+    # Call the function
+    sc.deploy_seedkit(
+        seedkit_name="test-seedkit",
+        vpc_id="vpc-12345",
+        subnet_ids=["subnet-1", "subnet-2"],
+        security_group_ids=["sg-1", "sg-2"],
+        permissions_boundary_arn="arn:aws:iam::123456789012:policy/boundary",
+    )
+
+    # Verify the deploy_template was called with correct parameters
+    mock_deploy.assert_called_once()
+    args, kwargs = mock_deploy.call_args
+
+    # Verify parameters dictionary contains expected values
+    parameters = kwargs["parameters"]
+    assert parameters["SeedkitName"] == "test-seedkit"
+    assert len(parameters["DeployId"]) == 6  # Random ID should be 6 chars
+    assert parameters["DeployCodeArtifact"] == "false"
+    assert parameters["VpcId"] == "vpc-12345"
+    assert parameters["SubnetIds"] == "subnet-1,subnet-2"
+    assert parameters["SecurityGroupIds"] == "sg-1,sg-2"
+    assert parameters["PermissionsBoundaryArn"] == "arn:aws:iam::123456789012:policy/boundary"
+
+
+@pytest.mark.commands
+@pytest.mark.commands_seedkit
+def test_deploy_seedkit_synthesize(mocker):
+    """Test synthesizing a seedkit template without deploying."""
+    # Mock the seedkit_deployed function
+    mocker.patch(
+        "seedfarmer.commands._seedkit_commands.seedkit_deployed", return_value=(False, "seedkit-test-stack", {})
+    )
+
+    # Mock the synth function
+    mock_synth = mocker.patch("seedfarmer.commands._cfn_seedkit.synth", return_value=None)
+
+    # Mock the deploy_template function
+    mock_deploy = mocker.patch("seedfarmer.services._cfn.deploy_template")
+
+    # Call the function
+    sc.deploy_seedkit(seedkit_name="test-seedkit", synthesize=True)
+
+    # Verify synth was called with synthesize=True
+    mock_synth.assert_called_once()
+    args, kwargs = mock_synth.call_args
+    assert kwargs["synthesize"] is True
+
+    # Verify deploy_template was not called
+    mock_deploy.assert_not_called()
+
+
+@pytest.mark.commands
+@pytest.mark.commands_seedkit
+def test_destroy_seedkit_existing(mocker):
+    """Test destroying an existing seedkit."""
+    # Mock the seedkit_deployed function
+    mocker.patch(
+        "seedfarmer.commands._seedkit_commands.seedkit_deployed",
+        return_value=(True, "seedkit-test-stack", {"Bucket": "test-bucket"}),
+    )
+
+    # Mock the S3 bucket deletion
+    mock_delete_bucket = mocker.patch("seedfarmer.services._s3.delete_bucket")
+
+    # Mock the CloudFormation stack deletion
+    mock_destroy_stack = mocker.patch("seedfarmer.services._cfn.destroy_stack")
+
+    # Call the function
+    sc.destroy_seedkit("test-seedkit")
+
+    # Verify the bucket was deleted
+    mock_delete_bucket.assert_called_once_with(bucket="test-bucket", session=None)
+
+    # Verify the stack was destroyed
+    mock_destroy_stack.assert_called_once_with(stack_name="seedkit-test-stack", session=None)
+
+
+@pytest.mark.commands
+@pytest.mark.commands_seedkit
+def test_destroy_seedkit_nonexistent(mocker):
+    """Test attempting to destroy a non-existent seedkit."""
+    # Mock the seedkit_deployed function
+    mocker.patch(
+        "seedfarmer.commands._seedkit_commands.seedkit_deployed", return_value=(False, "seedkit-test-stack", {})
+    )
+
+    # Mock the S3 bucket deletion
+    mock_delete_bucket = mocker.patch("seedfarmer.services._s3.delete_bucket")
+
+    # Mock the CloudFormation stack deletion
+    mock_destroy_stack = mocker.patch("seedfarmer.services._cfn.destroy_stack")
+
+    # Call the function
+    sc.destroy_seedkit("test-seedkit")
+
+    # Verify neither the bucket nor stack were deleted
+    mock_delete_bucket.assert_not_called()
+    mock_destroy_stack.assert_not_called()

--- a/test/unit-test/test_deployment_role_security.py
+++ b/test/unit-test/test_deployment_role_security.py
@@ -1,6 +1,6 @@
 import pytest
 
-from seedfarmer.commands._bootstrap_commands import get_deployment_template
+from seedfarmer.commands._bootstrap_commands import get_template
 
 
 @pytest.mark.commands
@@ -9,12 +9,7 @@ def test_deployment_role_deny_actions():
     """Test that the deployment role template includes the required deny actions for improved security posture."""
 
     # Get the deployment template using the same function the application uses
-    template = get_deployment_template(
-        toolchain_role_arn="arn:aws:iam::123456789012:role/test-role",
-        project_name="test-project",
-        role_name="test-deployment-role",
-        policy_arns=None,
-    )
+    template = get_template("deployment_role")
 
     # Expected deny actions that should be in the template
     expected_deny_actions = [


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Replace injection of CFN params via Jinja2 with CloudFormation Parameters and pass in dict of params when deploying CFN Template


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


Testing Completed:


- [ ] Deploy toolchain role template with params
     - [ ] Assert same resource as former toolchain role
     - [ ] Assert can specify and/or omit all optional params 

- [ ] Deploy deployment role template with params
     - [ ] Assert same resource as former toolchain role
     - [ ] Assert can specify and/or omit all optional params 

- [ ] Deploy seedkit IaC template with params
     - [ ] Assert same resource as former seedkit template
     - [ ] Assert can specify and/or omit all optional params 

- [ ] Added unit tests for coverage
