### PR TITLE
chore: fix no-op for existing modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ### Changes
 
 ### Fixes
+- make sure that a no-op occurs on module-init for deployment.yaml
 
 ## v7.0.1 (2025-06-25)
 

--- a/seedfarmer/mgmt/module_init.py
+++ b/seedfarmer/mgmt/module_init.py
@@ -136,7 +136,7 @@ def create_module_dir(
             output_dir=output_dir,
         )
 
-    add_module_manifest(module_name, module_path)
+        add_module_manifest(module_name, module_path)
 
 
 def create_project(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When module_init is invoked, a no-op occurs if the module exists, but the no-op excluded the update to the deployment.yaml

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
