### PR TITLE
fix: no checking for existing prebuild bundles on deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ### Fixes
 - improved local mode error handling
 - make sure that a no-op occurs on module-init for deployment.yaml
+- when deploying modules, never check for existing bundles
 
 ## v7.0.1 (2025-06-25)
 

--- a/seedfarmer/deployment/deploy_remote.py
+++ b/seedfarmer/deployment/deploy_remote.py
@@ -271,7 +271,7 @@ class DeployRemoteModule(DeployModule):
             codebuild_log_callback=None,
             session=SessionManager().get_or_create().get_deployment_session(account_id=account_id, region_name=region),
             bundle_id=bundle_id,
-            prebuilt_bundle=self._prebuilt_bundle_check(),
+            prebuilt_bundle=None,  # NEVER CHECK FOR THIS BUNDLE ON DEPLOY
             yaml_dumper=yaml,
         )
 


### PR DESCRIPTION
*Issue #, if available:*
#854 
*Description of changes:*
When deploying, we are checking for a pre-built bundle, when we should never do that

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
