### PR TITLE
fix: prime_accounts on destroy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ### Changes
 
 ### Fixes
+- prime_target_accounts on destroy - fix failed deployments on first apply cannot be destroyed
 
 ## v7.0.2 (2025-07-09)
 

--- a/seedfarmer/commands/_deployment_commands.py
+++ b/seedfarmer/commands/_deployment_commands.py
@@ -1028,6 +1028,11 @@ def destroy(
         _, _, partition = get_sts_identity_info(session=session_manager.toolchain_session)
         destroy_manifest._partition = partition
         destroy_manifest.validate_and_set_module_defaults()
+        prime_target_accounts(
+            deployment_manifest=destroy_manifest,
+            update_seedkit=False,
+            update_project_policy=False,
+        )
         destroy_deployment(
             destroy_manifest,
             remove_deploy_manifest=True,

--- a/test/unit-test/test_commands_deployment.py
+++ b/test/unit-test/test_commands_deployment.py
@@ -153,6 +153,7 @@ def test_destroy_clean(session_manager, mocker):
         return_value=DeploymentManifest(**mock_deployment_manifest_for_destroy.destroy_manifest),
     )
     mocker.patch("seedfarmer.commands._deployment_commands.destroy_deployment", return_value=None)
+    mocker.patch("seedfarmer.commands._deployment_commands.prime_target_accounts", return_value=None)
 
     dc.destroy(deployment_name="myapp", dryrun=True, remove_seedkit=False)
 
@@ -169,6 +170,7 @@ def test_destroy_not_found(session_manager, mocker):
         "seedfarmer.commands._bootstrap_commands.get_sts_identity_info",
         return_value=("1234566789012", "arn:aws", "aws"),
     )
+    mocker.patch("seedfarmer.commands._deployment_commands.prime_target_accounts", return_value=None)
 
     dc.destroy(deployment_name="myapp", dryrun=True, remove_seedkit=False)
 
@@ -181,6 +183,7 @@ def test_destroy_with_prefix(session_manager, mocker):
         return_value=DeploymentManifest(**mock_deployment_manifest_for_destroy.destroy_manifest),
     )
     mocker.patch("seedfarmer.commands._deployment_commands.destroy_deployment", return_value=None)
+    mocker.patch("seedfarmer.commands._deployment_commands.prime_target_accounts", return_value=None)
 
     dc.destroy(deployment_name="myapp", role_prefix="/test/", dryrun=True, remove_seedkit=False)
 
@@ -487,6 +490,7 @@ def test_destroy_generic_module_deployment_role(session_manager, mocker):
         return_value="generic-module-deployment-role",
     )
     mocker.patch("seedfarmer.commands._deployment_commands.destroy_module_deployment_role", return_value=None)
+    mocker.patch("seedfarmer.commands._deployment_commands.prime_target_accounts", return_value=None)
 
     dep = DeploymentManifest(**mock_deployment_manifest_huge.deployment_manifest)
     dep.validate_and_set_module_defaults()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
If a deployment fails on the first attempt, it cannot be destroy b/c the deployment manifest does not have a reference to the target account metadata.  Force a prime_accounts on destroy remediates this use case error

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
