### PR TITLE
fix: uv install with codeartifact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 
 ### Fixes
 
-- install uv via pip in remote deployment
+- install uv via pip in remote deployment, add uv.config path
 - unpin urllib3 due to CVE-2025-50181
 
 ## v7.0.3 (2025-07-18)

--- a/seedfarmer/deployment/deploy_remote.py
+++ b/seedfarmer/deployment/deploy_remote.py
@@ -60,12 +60,8 @@ class DeployRemoteModule(DeployModule):
             install.append("mv $CODEBUILD_SRC_DIR/bundle/npm_mirror_support.py /var/scripts/npm_mirror_support.py")
             install.append(f"/var/scripts/npm_mirror_support.py {npm_mirror} && echo 'NPM Mirror Set'")
 
-        install.append("pip install uv")
-        install.append("export PATH=$PATH:~/.local/bin")
-        install.append(f"uv venv ~/.venv --python {python_version} --seed")
-        install.append(". ~/.venv/bin/activate")
-
         if stack_outputs and "CodeArtifactDomain" in stack_outputs and "CodeArtifactRepository" in stack_outputs:
+            ## Need to configure pip BEFORE installing uv
             domain = stack_outputs["CodeArtifactDomain"]
             repo = stack_outputs["CodeArtifactRepository"]
             region = str(module_manifest.target_region)
@@ -90,6 +86,11 @@ class DeployRemoteModule(DeployModule):
             )
             install.append("export UV_INDEX_CODEARTIFACT_USERNAME=aws")
             install.append('export UV_INDEX_CODEARTIFACT_PASSWORD="$CODEARTIFACT_AUTH_TOKEN"')
+
+        install.append("pip install uv")
+        install.append("export PATH=$PATH:~/.local/bin")
+        install.append(f"uv venv ~/.venv --python {python_version} --seed")
+        install.append(". ~/.venv/bin/activate")
 
         # needed to make sure both the tool and lib are accessible in the venv
         install.append("uv pip install pip")

--- a/seedfarmer/deployment/deploy_remote.py
+++ b/seedfarmer/deployment/deploy_remote.py
@@ -61,7 +61,7 @@ class DeployRemoteModule(DeployModule):
             install.append(f"/var/scripts/npm_mirror_support.py {npm_mirror} && echo 'NPM Mirror Set'")
 
         install.append("pip install uv")
-        install.append("export PATH=$PATH:/root/.local/bin")
+        install.append("export PATH=$PATH:~/.local/bin")
         install.append(f"uv venv ~/.venv --python {python_version} --seed")
         install.append(". ~/.venv/bin/activate")
 
@@ -70,6 +70,7 @@ class DeployRemoteModule(DeployModule):
             repo = stack_outputs["CodeArtifactRepository"]
             region = str(module_manifest.target_region)
             account_id = str(module_manifest.get_target_account_id())
+            install.append("mkdir -p ~/.config/uv")
             install.append(
                 "cat <<EOF > ~/.config/uv/uv.toml\n"
                 "[[index]]\n"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When using codeartifact to source seedfarmer, the path for uv.config did not exist...adding 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
