### PR TITLE
fix: set the mirror env parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ### Changes
 
 ### Fixes
+- set the npm and pypi mirror secrets when set in module manifest
 
 ## v7.0.5 (2025-07-31)
 

--- a/docs/source/module_development.md
+++ b/docs/source/module_development.md
@@ -84,9 +84,9 @@ The currently supported values are:
 - BUILD_GENERAL1_2XLARGE
 ```
 
-The parameter `publishGenericEnvVariables`is a boolean and was implemented to support generic modules (deploy regardless of project name) and project-specific modules (ex ADDF).  This parameter defaults to `false` implying the prefix of the project to the pertient environment parameters in the codebuild environment.  When developing generic modules (modules for reuse regardless of project) this parameter MUST be set to `true`.  
+The parameter `publishGenericEnvVariables`is a boolean and was implemented to support generic modules (deploy regardless of project name) and project-specific modules (ex ADDF).  This parameter defaults to `true` implying the prefix of SeedFarmer to the environment parameters in the codebuild environment (`SEEDFARMER_PARAMETER_`).  When developing modules specific to a project (EX `ADDF_PARAMETER_` this parameter MUST be set to `FALSE` in order to prefix the project name.
 
-[This Pull Request goes into detail ...please read](https://github.com/awslabs/seed-farmer/pull/249).  Here is an exerpt:
+[This Pull Request goes into detail ...please read](https://github.com/awslabs/seed-farmer/pull/249).  Here is an excerpt:
 
 *When creating a module, builders can now specify the optional publishGenericEnvVariables attribute in the module deployspec.yaml. When set to true the Env Variables passed to CodeBuild for SeedFarmer metadata (ProjectName, DeploymentName, ModuleName, etc) are prefixed with SEEDFARMER_ rather than the UPPER ProjectName. From the included exampleproj project in examples: EXAMPLEPROJ_DEPLOYMENT_NAME would be SEEDFARMER_DEPLOYMENT_NAME. And for Module Parameters, EXAMPLEPROJ_PARAMETER_SOME_PARAMETER would be SEEDFARMER_PARAMETER_SOME_PARAMETER.*
 

--- a/seedfarmer/deployment/deploy_base.py
+++ b/seedfarmer/deployment/deploy_base.py
@@ -119,10 +119,10 @@ class DeployModule:
         if self.mdo.docker_credentials_secret:
             env_vars["AWS_CODESEEDER_DOCKER_SECRET"] = self.mdo.docker_credentials_secret  # (LEGACY)
             env_vars["SEEDFARMER_DOCKER_SECRET"] = self.mdo.docker_credentials_secret
-        if self.mdo.pypi_mirror_secret is not None:
+        if pypi_mirror_secret is not None:
             env_vars["AWS_CODESEEDER_PYPI_MIRROR_SECRET"] = str(pypi_mirror_secret)  # (LEGACY)
             env_vars["SEEDFARMER_PYPI_MIRROR_SECRET"] = str(pypi_mirror_secret)
-        if self.mdo.npm_mirror_secret is not None:
+        if npm_mirror_secret is not None:
             env_vars["AWS_CODESEEDER_NPM_MIRROR_SECRET"] = str(npm_mirror_secret)  # (LEGACY)
             env_vars["SEEDFARMER_NPM_MIRROR_SECRET"] = str(npm_mirror_secret)
         # Add the partition to env for ease of fetching


### PR DESCRIPTION
*Issue #, if available:*
#882 
*Description of changes:*
The pypiMirrorSecrets and npmMirrorSecrets were not being set in the codebuild env.  This corrects it and also removes some verbose logging when installing seedfarmer and supporting envs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
