### PR TITLE
fix: parameter types in codebuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 
 ### Fixes
 - fix cloudwatch_log_stream key missing in codebuild metadata model
+- add the proper parameter types (PARAMETER_STORE and SECRETS_MANAGER) to codebuild env types when defined in manifests
 
 
 ## v7.0.7 (2025-08-13)

--- a/seedfarmer/deployment/deploy_base.py
+++ b/seedfarmer/deployment/deploy_base.py
@@ -15,7 +15,7 @@
 
 import json
 import logging
-from typing import Dict, Optional, cast
+from typing import Dict, Optional, Union, cast
 
 from boto3 import Session
 
@@ -73,7 +73,7 @@ class DeployModule:
         else:
             return None
 
-    def _env_vars(self, session: Optional[Session] = None) -> Dict[str, str]:
+    def _env_vars(self, session: Optional[Session] = None) -> Dict[str, Union[str, EnvVar]]:
         use_project_prefix = not self.module_manifest.deploy_spec.publish_generic_env_variables  # type: ignore [union-attr]
         pypi_mirror_secret = (
             self.module_manifest.pypi_mirror_secret
@@ -129,4 +129,4 @@ class DeployModule:
         env_vars["AWS_PARTITION"] = str(self.mdo.deployment_manifest._partition)
         env_vars["SEEDFARMER_VERSION"] = seedfarmer.__version__
         # return env_vars
-        return {k: v if isinstance(v, str) else v.value for k, v in env_vars.items()}
+        return {k: v if isinstance(v, (str, EnvVar)) else v.value for k, v in env_vars.items()}

--- a/seedfarmer/deployment/deploy_local.py
+++ b/seedfarmer/deployment/deploy_local.py
@@ -26,6 +26,7 @@ from seedfarmer.deployment.deploy_base import DeployModule
 from seedfarmer.errors import InvalidConfigurationError
 from seedfarmer.models.deploy_responses import ModuleDeploymentResponse, StatusType
 from seedfarmer.models.manifests import ModuleManifest
+from seedfarmer.types.parameter_types import EnvVar
 from seedfarmer.utils import LiteralStr, apply_literalstr, create_output_dir, register_literal_str
 
 
@@ -218,7 +219,9 @@ class DeployLocalModule(DeployModule):
             # file.write(yaml.dump(buildspec))
             yaml.dump(buildspec, file)
 
-        build_info = codebuild_local.run(local_path, env_vars, codebuild_image)
+        build_info = codebuild_local.run(
+            local_path, {k: v.value if isinstance(v, EnvVar) else v for k, v in env_vars.items()}, codebuild_image
+        )
 
         return ModuleDeploymentResponse(
             deployment=self.mdo.deployment_manifest.name,
@@ -333,7 +336,9 @@ class DeployLocalModule(DeployModule):
         with open(os.path.join(buildspec_dir, "buildspec.yaml"), "w") as file:
             yaml.dump(buildspec, file)
 
-        build_info = codebuild_local.run(local_path, env_vars, codebuild_image)
+        build_info = codebuild_local.run(
+            local_path, {k: v.value if isinstance(v, EnvVar) else v for k, v in env_vars.items()}, codebuild_image
+        )
 
         return ModuleDeploymentResponse(
             deployment=deployment_name,


### PR DESCRIPTION
*Issue #, if available:*
#896 

*Description of changes:*
The Codebuild Type parameter for PARAMETER_STORE and SECRETS_MANAGER  in environment when defined in manifests.

<img width="1213" height="62" alt="Screenshot 2025-08-29 at 11 39 51 AM" src="https://github.com/user-attachments/assets/4322b501-a93a-496a-9afa-a4a527787280" />
<img width="1210" height="63" alt="Screenshot 2025-08-29 at 11 39 43 AM" src="https://github.com/user-attachments/assets/bf40d8bc-dea9-4605-beb7-ff4b8fcad074" />



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
