### PR TITLE
fix: use proper session to create hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ### Changes
 
 ### Fixes
+- remote deployments now generating hash based on active session passed in
 
 
 ## v7.0.8 (2025-08-29)

--- a/seedfarmer/deployment/deploy_remote.py
+++ b/seedfarmer/deployment/deploy_remote.py
@@ -112,7 +112,9 @@ class DeployRemoteModule(DeployModule):
             raise seedfarmer.errors.InvalidConfigurationError("Missing `deploy` in module's deployspec.yaml")
 
         use_project_prefix = not module_manifest.deploy_spec.publish_generic_env_variables
-        env_vars = self._env_vars()
+        env_vars = self._env_vars(
+            session=SessionManager().get_or_create().get_deployment_session(account_id=account_id, region_name=region)
+        )
 
         env_vars[DeployModule.seedfarmer_param("MODULE_MD5", None, use_project_prefix)] = (
             module_manifest.bundle_md5 if module_manifest.bundle_md5 is not None else ""
@@ -319,7 +321,9 @@ class DeployRemoteModule(DeployModule):
                 f"Missing `destroy` in module: {module_manifest.name} with deployspec.yaml"
             )
 
-        env_vars = self._env_vars()
+        env_vars = self._env_vars(
+            session=SessionManager().get_or_create().get_deployment_session(account_id=account_id, region_name=region)
+        )
         remove_ssm = [
             (
                 f"seedfarmer remove moduledata "


### PR DESCRIPTION
*Issue #, if available:*
#901 

*Description of changes:*
When creating the hash based off the session in remote deployments, the session corresponding to account/region was not referenced, defaulting to the active session - which created improper hashes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
