### PR TITLE
chore: adding CWLArn and allow empty string in PBA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ### New 
 
 ### Changes
+- adding the Cloudwatch Log Stream ARN to module metadata output
+- allow a permissionBoundaryName to be empty string as input, but resolves to None
 
 ### Fixes
 

--- a/seedfarmer/models/manifests/_deployment_manifest.py
+++ b/seedfarmer/models/manifests/_deployment_manifest.py
@@ -542,11 +542,10 @@ class DeploymentManifest(CamelModel):
             account_id=target_account,
             region=target_region,
         )
-        return (
-            f"arn:{self._partition}:iam::{target_account}:policy/{permissions_boundary_name}"
-            if permissions_boundary_name is not None
-            else None
-        )
+        if permissions_boundary_name in [None, "", " ", "", " "]:
+            return None
+        else:
+            return f"arn:{self._partition}:iam::{target_account}:policy/{permissions_boundary_name}"
 
     def validate_and_set_module_defaults(self) -> None:
         for group in self.groups:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- add the CloudwatchLogStream ARN to the module metadata output
- allow an empty string for a permissionBoundaryName as input, convert to None


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
