### PR TITLE
chore: add project name flag support for bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 
 ### Fixes
 - enable KMS key rotation for seedkit template
+- support using project name parameter 
+  - implemented for all, but used by bootstrap commands
 
 
 ## v7.0.10 (2025-09-17)

--- a/seedfarmer/__init__.py
+++ b/seedfarmer/__init__.py
@@ -111,6 +111,7 @@ class Config(object):
     _OPS_ROOT: Optional[str] = None
 
     _project_spec: Optional[ProjectSpec] = None
+    _project_name_param: Optional[str] = None
 
     def _load_config_data(self) -> None:
         count = 0
@@ -147,6 +148,9 @@ class Config(object):
 
     @property
     def PROJECT(self) -> str:
+        if self._project_name_param and self._project_spec is None:
+            return self._project_name_param
+
         if self._project_spec is None:
             self._load_config_data()
         return str(cast(ProjectSpec, self._project_spec).project)
@@ -192,6 +196,9 @@ class Config(object):
         if self._project_spec is None:
             self._load_config_data()
         return SEEDKIT_YAML_NAME
+
+    def set_project_name(self, project_name_param: str) -> None:
+        self._project_name_param = project_name_param
 
 
 config = Config()

--- a/seedfarmer/cli_groups/_bootstrap_group.py
+++ b/seedfarmer/cli_groups/_bootstrap_group.py
@@ -143,6 +143,8 @@ def bootstrap_toolchain(
         enable_debug(format=DEBUG_LOGGING_FORMAT)
     if project is None:
         project = _load_project()
+    else:
+        config.set_project_name(project)
     _logger.debug("Bootstrapping a Toolchain account for Project %s", project)
     if len(policy_arn) > 0 and not as_target:  # type: ignore
         raise click.ClickException("Cannot set PolicyARNS when the `-as-target` flag is not set.")
@@ -245,6 +247,8 @@ def bootstrap_target(
         enable_debug(format=DEBUG_LOGGING_FORMAT)
     if project is None:
         project = _load_project()
+    else:
+        config.set_project_name(project)
     _logger.debug("Bootstrapping a Target account for Project %s", project)
     bootstrap_target_account(
         toolchain_account_id=toolchain_account,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Allow project name flag to be used if passed in whenever the full project config is not needed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
