### PR TITLE
fix: permissions on deployment role for key rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ### Changes
 
 ### Fixes
+- permissions on deployment role missing kms:EnableKeyRotation from 7.0.11
 
 
 ## v7.0.11 (2025-10-23)

--- a/seedfarmer/resources/deployment_role.template
+++ b/seedfarmer/resources/deployment_role.template
@@ -96,6 +96,7 @@ Resources:
               - kms:DescribeKey
               - kms:CreateAlias
               - kms:DeleteAlias
+              - kms:EnableKeyRotation
               Effect: Allow
               Resource: '*'
               Sid: DeploymentKMSKey


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In release 7.0.11, seedkit added feature to rotate KMS keys, the deployment role needed the permissions to deploy the seedkit with this feature

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
