### PR TITLE
support KMS disabled

### DIFF
--- a/seedfarmer/commands/_deployment_commands.py
+++ b/seedfarmer/commands/_deployment_commands.py
@@ -398,6 +398,7 @@ def _deploy_validated_deployment(
 def prime_target_accounts(
     deployment_manifest: DeploymentManifest,
     update_seedkit: bool = False,
+    enable_seedkit_kms: bool = True,
     update_project_policy: bool = False,
 ) -> None:
     _logger.info("Priming Accounts")
@@ -441,6 +442,7 @@ def prime_target_accounts(
                 "account_id": account_id,
                 "region": region,
                 "update_seedkit": update_seedkit,
+                "enable_seedkit_kms": enable_seedkit_kms,
                 "update_project_policy": update_project_policy,
                 "permissions_boundary_arn": permissions_boundary_arn,
             }
@@ -932,6 +934,7 @@ def apply(
     prime_target_accounts(
         deployment_manifest=deployment_manifest,
         update_seedkit=update_seedkit,
+        enable_seedkit_kms=config.enable_seedkit_kms,
         update_project_policy=update_project_policy,
     )
 

--- a/seedfarmer/commands/_seedkit_commands.py
+++ b/seedfarmer/commands/_seedkit_commands.py
@@ -62,15 +62,16 @@ def deploy_seedkit(
     security_group_ids: Optional[List[str]] = None,
     permissions_boundary_arn: Optional[str] = None,
     synthesize: bool = False,
+    enable_seedkit_kms: bool = True,
     **kwargs: Dict[str, Any],
 ) -> None:
     """Deploys the seedkit resources into the environment.
 
     Resources deployed include: S3 Bucket, CodeArtifact Domain, CodeArtifact Repository, CodeBuild Project,
-    IAM Role, IAM Managed Policy, and KMS Key. All resource names will include the seedkit_name and IAM Role and Policy
-    grant least privilege access to only the resources associated with this Seedkit. Seedkits are deployed to an
-    AWS Region, names on global resources (S3, IAM) include a region identifier to avoid conflicts and ensure the same
-    Seedkit name can be deployed to multiple regions.
+    IAM Role, IAM Managed Policy, and KMS Key (if enabled). All resource names will include the seedkit_name
+    and IAM Role and Policy grant least privilege access to only the resources associated with this Seedkit.
+    Seedkits are deployed to an AWS Region, names on global resources (S3, IAM) include a region identifier
+    to avoid conflicts and ensure the same Seedkit name can be deployed to multiple regions.
 
     Parameters
     ----------
@@ -97,6 +98,8 @@ def deploy_seedkit(
         If using a permissions boundary, the arn of that policy to be provided
     synthesize: bool
         Synthesize seedkit template only. Do not deploy. False by default.
+    enable_seedkit_kms: bool
+        Whether to create a KMS key for the seedkit. Default is True.
     """
     deploy_id: Optional[str] = None
     stack_exists, stack_name, stack_outputs = seedkit_deployed(seedkit_name=seedkit_name, session=session)
@@ -144,6 +147,9 @@ def deploy_seedkit(
     # Only add SubnetIds if it's not None
     if subnet_ids:
         parameters["SubnetIds"] = ",".join(subnet_ids)
+
+    # Add EnableSeedkitKMS parameter
+    parameters["EnableSeedkitKMS"] = str(enable_seedkit_kms).lower()
 
     if not synthesize:
         assert template_filename is not None, "Template filename is required"

--- a/seedfarmer/commands/_stack_commands.py
+++ b/seedfarmer/commands/_stack_commands.py
@@ -587,6 +587,7 @@ def deploy_seedkit(
     private_subnet_ids: Optional[List[str]] = None,
     security_group_ids: Optional[List[str]] = None,
     update_seedkit: Optional[bool] = False,
+    enable_seedkit_kms: bool = True,
     role_prefix: Optional[str] = None,
     policy_prefix: Optional[str] = None,
     permissions_boundary_arn: Optional[str] = None,
@@ -640,6 +641,7 @@ def deploy_seedkit(
             seedkit_args["policy_prefix"] = policy_prefix
         if permissions_boundary_arn:
             seedkit_args["permissions_boundary_arn"] = permissions_boundary_arn
+        seedkit_args["enable_seedkit_kms"] = enable_seedkit_kms
 
         sk_commands.deploy_seedkit(**seedkit_args)  # type: ignore [arg-type]
         # Go get the outputs and return them

--- a/seedfarmer/models/_project_spec.py
+++ b/seedfarmer/models/_project_spec.py
@@ -32,6 +32,7 @@ class ProjectSpec(CamelModel):
     project_policy_path: Optional[str] = None
     seedfarmer_version: Optional[Union[int, str]] = None
     manifest_validation_fail_on_unknown_fields: bool = False
+    enable_seedkit_kms: bool = True
 
     @model_validator(mode="after")
     def check_for_extra_fields(self) -> "ProjectSpec":

--- a/seedfarmer/resources/seedkit.template
+++ b/seedfarmer/resources/seedkit.template
@@ -46,6 +46,13 @@ Parameters:
     Type: String
     Description: Permission Boundary to set on the role
     Default: ""
+  EnableSeedkitKMS:
+    Type: String
+    Description: Enable creation of KMS key for seedkit
+    Default: "true"
+    AllowedValues:
+      - "true"
+      - "false"
 
 Conditions:
   HasManagedPolicies:
@@ -82,6 +89,10 @@ Conditions:
       - Fn::Equals:
           - Ref: PermissionsBoundaryArn
           - ""
+  EnableSeedkitKMSEnabled:
+    Fn::Equals:
+      - Ref: EnableSeedkitKMS
+      - "true"
 
 Resources:
   Bucket:
@@ -101,9 +112,18 @@ Resources:
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
       BucketEncryption:
-        ServerSideEncryptionConfiguration:
-          - ServerSideEncryptionByDefault:
-              SSEAlgorithm: AES256
+        Fn::If:
+          - EnableSeedkitKMSEnabled
+          - ServerSideEncryptionConfiguration:
+              - ServerSideEncryptionByDefault:
+                  SSEAlgorithm: aws:kms
+                  KMSMasterKeyID:
+                    Fn::GetAtt:
+                      - KmsKey
+                      - Arn
+          - ServerSideEncryptionConfiguration:
+              - ServerSideEncryptionByDefault:
+                  SSEAlgorithm: AES256
       LifecycleConfiguration:
         Rules:
           - Id: CleaningUp
@@ -184,19 +204,25 @@ Resources:
               - ssm:DescribeParameters
             Resource:
               - Fn::Sub: arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:*
-          - Effect: Allow
-            Action:
-              - kms:*
-            Resource:
-              - Fn::Sub: arn:${AWS::Partition}:kms:${AWS::Region}:${AWS::AccountId}:alias/codeseeder-${SeedkitName}*
-              - Fn::Sub: arn:${AWS::Partition}:kms:${AWS::Region}:${AWS::AccountId}:key/*
-          - Effect: Allow
-            Action:
-              - sts:GetServiceBearerToken
-            Resource: '*'
-            Condition:
-              StringEquals:
-                sts:AWSServiceName: codeartifact.amazonaws.com
+          - Fn::If:
+              - EnableSeedkitKMSEnabled
+              - Effect: Allow
+                Action:
+                  - kms:*
+                Resource:
+                  - Fn::Sub: arn:${AWS::Partition}:kms:${AWS::Region}:${AWS::AccountId}:alias/codeseeder-${SeedkitName}*
+                  - Fn::Sub: arn:${AWS::Partition}:kms:${AWS::Region}:${AWS::AccountId}:key/*
+              - Ref: AWS::NoValue
+          - Fn::If:
+              - DeployCodeArtifactEnabled
+              - Effect: Allow
+                Action:
+                  - sts:GetServiceBearerToken
+                Resource: '*'
+                Condition:
+                  StringEquals:
+                    sts:AWSServiceName: codeartifact.amazonaws.com
+              - Ref: AWS::NoValue
           - Effect: Allow
             Action:
               - codecommit:*
@@ -209,25 +235,31 @@ Resources:
               - Fn::Sub: arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:codeseeder-${SeedkitName}-*
               - Fn::Sub: arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:*-docker-credentials*
               - Fn::Sub: arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:*-mirror-credentials*
-          - Effect: Allow
-            Action:
-              - codeartifact:Create*
-              - codeartifact:DeleteDomain
-              - codeartifact:DeleteRepository
-              - codeartifact:Describe*
-              - codeartifact:Get*
-              - codeartifact:List*
-              - codeartifact:TagResource
-              - codeartifact:Associate*
-            Resource:
-              - Fn::Sub: arn:${AWS::Partition}:codeartifact:${AWS::Region}:${AWS::AccountId}:domain/aws-codeseeder-${SeedkitName}*
-              - Fn::Sub: arn:${AWS::Partition}:codeartifact:${AWS::Region}:${AWS::AccountId}:repository/aws-codeseeder-${SeedkitName}*
-          - Effect: Allow
-            Action:
-              - codeartifact:GetAuthorizationToken
-              - codeartifact:GetRepositoryEndpoint
-              - codeartifact:ReadFromRepository
-            Resource: '*'
+          - Fn::If:
+              - DeployCodeArtifactEnabled
+              - Effect: Allow
+                Action:
+                  - codeartifact:Create*
+                  - codeartifact:DeleteDomain
+                  - codeartifact:DeleteRepository
+                  - codeartifact:Describe*
+                  - codeartifact:Get*
+                  - codeartifact:List*
+                  - codeartifact:TagResource
+                  - codeartifact:Associate*
+                Resource:
+                  - Fn::Sub: arn:${AWS::Partition}:codeartifact:${AWS::Region}:${AWS::AccountId}:domain/aws-codeseeder-${SeedkitName}*
+                  - Fn::Sub: arn:${AWS::Partition}:codeartifact:${AWS::Region}:${AWS::AccountId}:repository/aws-codeseeder-${SeedkitName}*
+              - Ref: AWS::NoValue
+          - Fn::If:
+              - DeployCodeArtifactEnabled
+              - Effect: Allow
+                Action:
+                  - codeartifact:GetAuthorizationToken
+                  - codeartifact:GetRepositoryEndpoint
+                  - codeartifact:ReadFromRepository
+                Resource: '*'
+              - Ref: AWS::NoValue
           - Effect: Allow
             Action:
               - s3:List*
@@ -396,6 +428,7 @@ Resources:
 
   KmsKeyAlias:
     Type: AWS::KMS::Alias
+    Condition: EnableSeedkitKMSEnabled
     Properties:
       AliasName: 
         Fn::Sub: alias/codeseeder-${SeedkitName}-${DeployId}
@@ -404,6 +437,7 @@ Resources:
 
   KmsKey:
     Type: AWS::KMS::Key
+    Condition: EnableSeedkitKMSEnabled
     Properties:
       EnableKeyRotation: true
       Tags:
@@ -487,6 +521,7 @@ Outputs:
         Fn::Sub: codeseeder-${SeedkitName}-bucket
 
   KmsKeyArn:
+    Condition: EnableSeedkitKMSEnabled
     Value:
       Fn::GetAtt:
         - KmsKey


### PR DESCRIPTION
*Issue #957 

*Description of changes:*
I found that: KMS key is enabled in our seedkit.template by default and this cannot be disabled. However, this key is not used either by S3 buckets or any resources created by the seedkit.templates.

Additionally, when codeartifact disabled, should not create any permissions of that service.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
