### PR TITLE
fix: naming convention collision on project policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ### Changes
 
 ### Fixes
-
+- `resources/projectpolicy.yaml` had a policy global naming conflict, postpend the region to the name
 
 ## v8.0.5 (2026-04-08)
 

--- a/seedfarmer/resources/projectpolicy.yaml
+++ b/seedfarmer/resources/projectpolicy.yaml
@@ -15,7 +15,7 @@ Resources:
     Type: AWS::IAM::ManagedPolicy
     Properties:
       ManagedPolicyName:
-        Fn::Sub: "${ProjectName}-managed-policy"
+        Fn::Sub: "${ProjectName}-managed-policy-${AWS::Region}"
       Description: Managed Policy granting access to build a project
       Path: /
       PolicyDocument:

--- a/test/unit-test/test_iam_role_templates.py
+++ b/test/unit-test/test_iam_role_templates.py
@@ -459,7 +459,7 @@ class TestProjectPolicyTemplate:
         props = projectpolicy_template["Resources"]["ProjectPolicy"]["Properties"]
         assert "ManagedPolicyName" in props
         name_sub = props["ManagedPolicyName"]["Fn::Sub"]
-        assert "${ProjectName}-managed-policy" == name_sub
+        assert "${ProjectName}-managed-policy-${AWS::Region}" == name_sub
 
     def test_ssm_uses_lowercase_only(self, projectpolicy_template):
         """SSM resources use ${ProjectNameLower} — no SCP requirement, lowercase for consistency."""


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
the `resources/projectpolicy.yaml` is deployed in each region but IAM is global, so post-pending the region name to policy name guarantees that each SF project for account+region has a unique name

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
